### PR TITLE
Various chnages to make dev installation easier

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,9 @@ before_install:
 #  - codecov
 
 script:
+    - composer validate
     - composer install
-    - phpunit --coverage-clover=coverage.xml
+    - ./vendor/bin/phpunit --coverage-clover=coverage.xml
     - codecov
 
 sudo: false

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Installation
 To install xtools, follow these steps:
 
 1. Clone or download this repository.
-2. Run "composer install".  This will prompt for a series of questions, including database credientials.  
+2. Run "composer install".  This will prompt for a series of questions, including database credentials.
 3. Run in web server.
 4. ???
 5. Profit!

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -62,7 +62,7 @@
                 <ul class="dropdown-menu">
                     {% for key, value in allLangs() %}
                         <li>
-                            <a class="lang-link" href="{{ link(path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'uselang': key}))) }}" data-lang="{{ key }}">{{ value|e }}</a>
+                            <a class="lang-link" href="{{ path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'uselang': key})) }}" data-lang="{{ key }}">{{ value|e }}</a>
                         </li>
                     {% endfor %}
                 </ul>
@@ -71,10 +71,14 @@
         </div>
         <nav class="top-nav navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-left">
-                <li{% if page is defined and page=="index" %} class="active"{% endif %} ><a href="{{ link("/") }}">{{ msg("title_xtools") }}</a></li>
+                <li{% if page is defined and page=="index" %} class="active"{% endif %} ><a href="{{ path("homepage") }}">{{ msg("title_xtools") }}</a></li>
 
                 {% for tool in tools() %}
-                    {% if enabled(tool) %}<li{% if page is defined and page==tool %} class="active"{% endif %} ><a href="{{ link("/"~tool) }}">{{ msg("tool_" ~ tool) }}</a></li>{% endif %}
+                    {% if enabled(tool) %}
+                        <li{% if page is defined and page==tool %} class="active"{% endif %} >
+                            <a href="{{ path(tool) }}">{{ msg("tool_" ~ tool) }}</a>
+                        </li>
+                    {% endif %}
                 {% endfor %}
             </ul>
         </nav>
@@ -147,7 +151,7 @@
     <hr>
     <div class="row">
         <div class="col">
-            <span>&copy; 2008-{{ year() }} &middot; <a href="{{ link("/about") }}">About these tools</a>  &middot; v.{{ version }} &middot; <a href="http://github.com/x-tools/xtools-rebirth/tree/{{ hash() }}" target="_blank">r.{{ shortHash() }}</a> </span><br />
+            <span>&copy; 2008-{{ year() }} &middot; <a href="{{ path("aboutPage") }}">About these tools</a>  &middot; v.{{ version }} &middot; <a href="http://github.com/x-tools/xtools-rebirth/tree/{{ hash() }}" target="_blank">r.{{ shortHash() }}</a> </span><br />
             <span>{{ msg_footer() }}</span>
         </div>
         <div class="col pull-right">

--- a/app/Resources/views/default/index.html.twig
+++ b/app/Resources/views/default/index.html.twig
@@ -1,10 +1,12 @@
 {% extends 'base.html.twig' %}
 
 {% block body %}
-    We have the following tools available:
-    <ul>
-        {% for tool in tools() %}
-            {% if enabled(tool) %}<li><a href="{{ link("/" ~ tool) }}">{{ msg("tool_" ~ tool) }}</a></li>{% endif %}
-        {% endfor %}
-    </ul>
+    <div class="col-lg-8 col-lg-offset-2">
+        <p>We have the following tools available:</p>
+        <ul>
+            {% for tool in tools() %}
+                {% if enabled(tool) %}<li><a href="{{ path(tool) }}">{{ msg("tool_" ~ tool) }}</a></li>{% endif %}
+            {% endfor %}
+        </ul>
+    </div>
 {% endblock %}

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -39,20 +39,20 @@ parameters:
     app.replag_threshold: 30
 
     # Enabling or disabling of individual tools
-    enable.ec: 1
-    enable.articleinfo: 1
-    enable.pages: 1
-    enable.topedits: 1
-    enable.rangecontribs: 1
-    enable.blame: 1
-    enable.autoedits: 1
-    enable.autoblock: 1
-    enable.adminstats: 1
     enable.adminscore: 1
-    enable.rfa: 1
-    enable.rfap: 1
-    enable.bash: 1
+    enable.adminstats: 1
+    enable.articleinfo: 1
+    enable.autoblock: 0
+    enable.autoedits: 0
+    enable.bash: 0
+    enable.blame: 0
+    enable.ec: 1
+    enable.pages: 1
+    enable.rangecontribs: 0
+    enable.rfa: 0
+    enable.rfap: 0
     enable.sc: 1
+    enable.topedits: 1
 
     # Leave blank if xTools is installed in the root directory
     app.base_path:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
-    "name": "matthew/xtools.symfony",
-    "license": "proprietary",
+    "name": "xtools/xtools-rebirth",
+    "description": "A set of article and user statistics tools for MediaWiki sites",
+    "license": "GPL-3.0",
     "type": "project",
     "autoload": {
         "psr-4": {
@@ -18,7 +19,7 @@
     },
     "require": {
         "php": ">=5.5.9",
-        "symfony/symfony": "3.0.*",
+        "symfony/symfony": "^3.0",
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
         "doctrine/doctrine-cache-bundle": "^1.2",
@@ -37,6 +38,7 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",
+        "phpunit/phpunit": "^4.8",
         "symfony/phpunit-bridge": "^3.0"
     },
     "scripts": {

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -4,9 +4,9 @@ Development
 
 To contribute to the development of xTools, you may fork us on GitHub.  A few things to be aware of first:
 
-1. xTools is based on Symfony 3.0. We use Twig as our template engine.  Symfony is a full MVC system.
-  a. The controllers are located at ``src/AppBundle/controller``.  They are sorted by tool
-  b. The twig templates are located at ``app/resources/views``.  They are sorted by tool.
+1. xTools is based on Symfony 3. We use Twig as our template engine.  Symfony is a full MVC system.
+   a. The controllers are located at ``src/AppBundle/controller``.  They are sorted by tool
+   b. The twig templates are located at ``app/resources/views``.  They are sorted by tool.
 2. We use the ``@Route`` syntax to configure routes. 
 3. Every tool requires a twig directory and one controller. Also, core parts of xTools require the tool to be registered within `app/config/tools.yml`.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,7 +5,7 @@ Installation
 To install xTools, please follow these steps:
 
 1. Download the repository into your webserver root.
-2. Run ``composer install``
-3. Start your web server.
-4. Visit your domain in a browser.  You should see the xTools landing page
-5. In order to update the cache after making configuration changes, run ``sudo ./clear_cache.sh`` from the webserver root.
+2. Run ``composer install``.
+3. Ensure that ``var/`` and all files within it (other than ``var/SymfonyRequirements.php``) are writable by the web server.
+4. Visit your domain in a browser.  You should see the xTools landing page.
+5. In order to update the cache after making configuration changes, run ``./bin/console cache:clear``.

--- a/src/AppBundle/Controller/AdminScoreController.php
+++ b/src/AppBundle/Controller/AdminScoreController.php
@@ -11,6 +11,7 @@ use DateTime;
 class AdminScoreController extends Controller
 {
     /**
+     * @Route("/adminscore", name="adminscore")
      * @Route("/adminscore", name="AdminScore")
      * @Route("/adminscore/", name="AdminScoreSlash")
      * @Route("/adminscore/index.php", name="AdminScoreIndexPhp")

--- a/src/AppBundle/Controller/AdminStatsController.php
+++ b/src/AppBundle/Controller/AdminStatsController.php
@@ -10,6 +10,7 @@ class AdminStatsController extends Controller
 {
 
     /**
+     * @Route("/adminstats", name="adminstats")
      * @Route("/adminstats", name="AdminStats")
      * @Route("/adminstats/", name="AdminStatsSlash")
      * @Route("/adminstats/index.php", name="AdminStatsSlash")

--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -11,6 +11,7 @@ use AppBundle\Helper\Apihelper;
 class ArticleInfoController extends Controller
 {
     /**
+     * @Route("/articleinfo", name="articleinfo")
      * @Route("/articleinfo", name="articleInfo")
      * @Route("/articleinfo/", name="articleInfoSlash")
      * @Route("/articleinfo/index.php", name="articleInfoIndexPhp")

--- a/src/AppBundle/Controller/EditCounterController.php
+++ b/src/AppBundle/Controller/EditCounterController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class EditCounterController extends Controller
 {
     /**
+     * @Route("/ec", name="ec")
      * @Route("/ec", name="EditCounter")
      * @Route("/ec/", name="EditCounterSlash")
      * @Route("/ec/index.php", name="EditCounterIndexPhp")

--- a/src/AppBundle/Controller/PagesController.php
+++ b/src/AppBundle/Controller/PagesController.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class PagesController extends Controller
 {
     /**
+     * @Route("/pages", name="pages")
      * @Route("/pages", name="Pages")
      * @Route("/pages/", name="PagesSlash")
      * @Route("/pages/index.php", name="PagesIndexPhp")

--- a/src/AppBundle/Controller/SimpleEditCounterController.php
+++ b/src/AppBundle/Controller/SimpleEditCounterController.php
@@ -11,6 +11,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class SimpleEditCounterController extends Controller
 {
     /**
+     * @Route("/sc", name="sc")
      * @Route("/sc", name="SimpleEditCounter")
      * @Route("/sc/", name="SimpleEditCounterSlash")
      * @Route("/sc/index.php", name="SimpleEditCounterIndexPhp")

--- a/src/AppBundle/Controller/TopEditsController.php
+++ b/src/AppBundle/Controller/TopEditsController.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpFoundation\Request;
 class TopEditsController extends Controller
 {
     /**
+     * @Route("/topedits", name="topedits")
      * @Route("/topedits", name="topEdits")
      * @Route("/topedits/", name="topEditsSlash")
      * @Route("/topedits/index.php", name="topEditsIndex")


### PR DESCRIPTION
* Switch to Symfony 3.2
  (it's backwards compatible to 3.0 which is now not supported)
  to avoid "Twig_Error_Runtime: The "core" extension is not enabled."
* Add `composer validate` to the Travis checks.
* Use `path()` instead of `link()` to construct URLs,
  to account for when the application is loaded via app_dev.php
  or in a subdirectory.
* Give each tool's index route a name that matches that of the tool.
  This helps with constructing these URLs.
* Disable tools (by default) that have not yet been created in this repo.
* Fix license in composer.json and add a description (so the file validates).
* Add phpunit as a dev requirement, for developers who don't have it installed globally.
* Update some documentation.

Bug: GitHub #4