### PR TITLE
Add caching helper methods, and caching to API calls

### DIFF
--- a/src/AppBundle/Helper/HelperBase.php
+++ b/src/AppBundle/Helper/HelperBase.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace AppBundle\Helper;
+
+use DateInterval;
+use Symfony\Component\DependencyInjection\Container;
+
+abstract class HelperBase
+{
+
+    /** @var Container */
+    protected $container;
+
+    /**
+     * Get a cache key.
+     * @param string $key
+     * @return string The key with a representation of the class name prefixed.
+     */
+    private function getCacheKey($key)
+    {
+        return str_replace('\\', '', get_class($this)).'.'.$key;
+    }
+
+    /**
+     * Find out whether the given key exists in the cache.
+     * @param string $key The cache key.
+     * @return boolean
+     */
+    protected function cacheHas($key)
+    {
+        /** @var \Symfony\Component\Cache\Adapter\AdapterInterface $cache */
+        $cache = $this->container->get('cache.app');
+        return $cache->getItem($this->getCacheKey($key))->isHit();
+    }
+
+    /**
+     * Get a value from the cache. With this it is not possible to tell the difference between a
+     * cached value of 'null' and there being no cached value; if that situation is likely, you
+     * should use the cache service directly.
+     * @param string $key The cache key.
+     * @return mixed|null Whatever's in the cache, or null if the key isn't present.
+     */
+    protected function cacheGet($key)
+    {
+        /** @var \Symfony\Component\Cache\Adapter\AdapterInterface $cache */
+        $cache = $this->container->get('cache.app');
+        $item = $cache->getItem($this->getCacheKey($key));
+        if ($item->isHit()) {
+            return $item->get();
+        }
+        return null;
+    }
+
+    /**
+     * Save a value to the cache.
+     * @param string $key The cache key.
+     * @param string $value The value to cache.
+     * @param string $expiresAfter A DateInterval interval specification.
+     */
+    protected function cacheSave($key, $value, $expiresAfter)
+    {
+        /** @var \Symfony\Component\Cache\Adapter\AdapterInterface $cache */
+        $cache = $this->container->get('cache.app');
+        $item = $cache->getItem($this->getCacheKey($key));
+        $item->set($value);
+        $item->expiresAfter(new DateInterval($expiresAfter));
+        $cache->save($item);
+    }
+}


### PR DESCRIPTION
This creates a few methods in a new Helper parent class, to make
it slightly easier to add caching to any helper.
Also some documentation.

Bug: https://phabricator.wikimedia.org/T161057

The specific TTLs here can be changed of course; I'm not sure what they should be. It depends on how people use the tools, but at least some things can be cached for quite a long while (to speed things up).
