### PR TITLE
Add global xtBaseUrl JS variable and use for API request

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -37,6 +37,9 @@
         <script src="{{ asset_url }}"></script>
         {% endjavascripts %}
     {% endif %}
+    <script type="text/javascript">
+        xtBaseUrl = "{{ absolute_url(path('homepage')) }}";
+    </script>
 
     <link rel="shortcut icon" href="/favicon.ico?v=3" />
 

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -188,7 +188,7 @@
 
             var newProject = this.value;
 
-            $.get('/api/namespaces/' + newProject).done(function (namespaces) {
+            $.get(xtBaseUrl + 'api/namespaces/' + newProject).done(function (namespaces) {
                 var $allOption = $('#namespace_select option').eq(0).clone();
                 $("#namespace_select").html($allOption);
                 for (var ns in namespaces) {
@@ -212,7 +212,6 @@
                 );
             }).always(function () {
                 $('#namespace_select').prop('disabled', false);
-                console.log('yeah');
             });
         });
     }


### PR DESCRIPTION
I don't think we're assuming top-level directory installation, so I've added this `xtBaseUrl` JS var that can be used to prefix all API requests etc.

(I was getting an error with the NS lookup. Which is a pretty cool feature by the way!)
