### PR TITLE
Add 'lang' parameter, and account for single_wiki in testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ php:
 
 # optionally specify a list of environments, for example to test different RDBMS
 env:
-  - IS_LABS=1
   - IS_LABS=0
 
 before_install:
@@ -22,7 +21,7 @@ before_install:
 
 install:
   - composer install
-  - 'sed -i "s/apps.is_labs: .*/apps.is_labs: $IS_LABS/" app/config/parameters.yml'
+  - 'sed -i "s/app.is_labs: .*/app.is_labs: $IS_LABS/" app/config/parameters.yml'
 
 script:
   - composer validate

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -18,7 +18,7 @@ parameters:
     database_toolsdb_name:      ~
 
     wiki_url:                   http://en.wikipedia.org
-
+    lang:                       en
     default_project:            en.wikipedia.org
 
     mailer_transport:  smtp

--- a/src/AppBundle/Controller/ApiController.php
+++ b/src/AppBundle/Controller/ApiController.php
@@ -4,11 +4,11 @@ namespace AppBundle\Controller;
 
 use AppBundle\Helper\ApiHelper;
 use AppBundle\Helper\LabsHelper;
+use Exception;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Config\Definition\Exception\Exception;
 use Symfony\Component\Debug\Exception\FatalErrorException;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Controller\FOSRestController;

--- a/src/AppBundle/Controller/TopEditsController.php
+++ b/src/AppBundle/Controller/TopEditsController.php
@@ -56,25 +56,15 @@ class TopEditsController extends Controller
             $project = $this->container->getParameter('default_project');
         }
 
-        // Retrieving the global groups, using the ApiHelper class
+        /** @var ApiHelper */
         $api = $this->get("app.api_helper");
-
-        // Try fetching namespaces. At this point $project has some sort of value
-        try {
-            $namespaces = $api->namespaces($project);
-        } catch (\Exception $e) {
-            // show error message and redirect back to default project
-            $this->addFlash("notice", [$e->getMessage()]);
-            $project = $this->container->getParameter('default_project');
-            return $this->redirectToRoute("PagesProject", [ 'project'=>$project ]);
-        }
 
         return $this->render('topedits/index.html.twig', [
             'xtPageTitle' => 'tool_topedits',
             'xtSubtitle' => 'tool_topedits_desc',
             'xtPage' => 'topedits',
             'project' => $project,
-            'namespaces' => $namespaces,
+            'namespaces' => $api->namespaces($project),
         ]);
     }
 

--- a/src/AppBundle/Helper/LabsHelper.php
+++ b/src/AppBundle/Helper/LabsHelper.php
@@ -46,7 +46,7 @@ class LabsHelper
      * Set up LabsHelper::$client and return the database name, wiki name, and URL of a given
      * project.
      * @todo: Handle failure better
-     * @return string[] With keys 'dbName', 'wikiName', and 'url'.
+     * @return string[] With keys 'dbName', 'wikiName', 'url', and 'lang'.
      */
     public function databasePrepare($project = 'wiki')
     {
@@ -54,6 +54,7 @@ class LabsHelper
             $dbName = $this->container->getParameter('database_replica_name');
             $wikiName = 'wiki';
             $url = $this->container->getParameter('wiki_url');
+            $lang = $this->container->getParameter('lang');
         } else {
             // First, run through our project map.  This is expected to return back
             // to the project name if there is no defined mapping.

--- a/tests/AppBundle/Controller/ApiControllerTest.php
+++ b/tests/AppBundle/Controller/ApiControllerTest.php
@@ -19,12 +19,17 @@ class ApiControllerTest extends WebTestCase
     public function testNamespaces()
     {
         $client = static::createClient();
+        $isSingle = $this->container->getParameter('app.single_wiki');
 
-        // test 404
+        // Test 404 (for single-wiki setups, that wiki's namespaces are always returned).
         $crawler = $client->request('GET', '/api/namespaces/wiki.that.doesnt.exist.org');
-        $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        if ($isSingle) {
+            $this->assertEquals(200, $client->getResponse()->getStatusCode());
+        } else {
+            $this->assertEquals(404, $client->getResponse()->getStatusCode());
+        }
 
-        if ($this->container->getParameter('app.is_labs')) {
+        if (!$isSingle && $this->container->getParameter('app.is_labs')) {
             $crawler = $client->request('GET', '/api/namespaces/fr.wikipedia.org');
             $this->assertEquals(200, $client->getResponse()->getStatusCode());
 

--- a/tests/AppBundle/Helper/LabsHelperTest.php
+++ b/tests/AppBundle/Helper/LabsHelperTest.php
@@ -27,7 +27,7 @@ class LabsHelperTest extends WebTestCase
         if ($this->container->getParameter('app.is_labs')) {
             // When using Labs.
             $this->assertEquals('_p.page', $this->labsHelper->getTable('page'));
-            $this->assertEquals('_p.logging_logindex', $this->labsHelper->getTable('logging'));
+            $this->assertEquals('_p.logging_userindex', $this->labsHelper->getTable('logging'));
         } else {
             // When using wiki databases directly.
             $this->assertEquals('page', $this->labsHelper->getTable('page'));


### PR DESCRIPTION
The lang defaults to English. Also fix Travis misconfiguration.

This reduces the amout Travis tests, I'm afraid: because we can't have 'single wiki' and 'is labs' at the same time, and so until we sort out better testing I think we just have to leave travis to do 'single wiki' and 'is not labs'.

I think the namespace-getting exception handling could be a bit clearer: there seem to be a few exceptions silently ignored.

But at least this passes the tests! :)
