### PR TITLE
Hidden params

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: defaults.yml }
     - { resource: parameters.yml }
     - { resource: security.yml }
     - { resource: services.yml }

--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -1,0 +1,8 @@
+parameters:
+    app.base_path: null
+    cache.adapter: filesystem
+    cache.redis_dsn: 'redis://localhost'
+    app.is_labs: 0
+    database_toolsdb_host: 127.0.0.1
+    database_toolsdb_port: null
+    database_toolsdb_name: null

--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -1,3 +1,7 @@
+# These are some WMF Tool Labs specific parameters.
+# Putting them here hides them from the composer install without breaking xtools. 
+# Manually add these settings to parameters.yml if you want to change them.
+
 parameters:
     app.base_path: null
     cache.adapter: filesystem

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -13,9 +13,6 @@ parameters:
     database_replica_user:      root
     database_replica_password:  ~
     database_meta_name:         meta_p
-    database_toolsdb_host:      127.0.0.1
-    database_toolsdb_port:      ~
-    database_toolsdb_name:      ~
 
     wiki_url:                   http://en.wikipedia.org
     lang:                       en
@@ -34,8 +31,6 @@ parameters:
     app.noticeDisplay: false
     app.noticeStyle:   ""
     app.noticeText:    ""
-
-    app.is_labs: 0
 
     app.load_stylesheets_from_cdn: 0
 
@@ -56,10 +51,3 @@ parameters:
     enable.rfap: 0
     enable.sc: 1
     enable.topedits: 1
-
-    # Leave blank if xTools is installed in the root directory
-    app.base_path:
-
-    # Caching.
-    cache.adapter: filesystem
-    cache.redis_dsn: redis://localhost


### PR DESCRIPTION
This change hides some parameters that are very unlikely to be used on a non WMF labs install.  We can still override them by manually setting them in parameters.yml, however; we don't need to prompt anyone doing a composer install.  