### PR TITLE
Require config option for API path, and use meta=siteinfo

### DIFF
--- a/app/Resources/views/macros/forms.html.twig
+++ b/app/Resources/views/macros/forms.html.twig
@@ -6,7 +6,7 @@
             <div class="tooltip-body">
                 <strong>Accepted formats:</strong>
                 <code>enwiki</code> or <code>en.wikipedia</code> or
-                <span class="text-nowrap"><code>https://en.wikipedia.org</code> &hellip;</span>
+                <span class="text-nowrap"><code>en.wikipedia.org</code></span>
             </div>
         </div>
     </label>

--- a/app/config/defaults.yml
+++ b/app/config/defaults.yml
@@ -1,5 +1,5 @@
 # These are some WMF Tool Labs specific parameters.
-# Putting them here hides them from the composer install without breaking xtools. 
+# Putting them here hides them from the composer install without breaking xtools.
 # Manually add these settings to parameters.yml if you want to change them.
 
 parameters:

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -15,6 +15,7 @@ parameters:
     database_meta_name:         meta_p
 
     wiki_url:                   http://en.wikipedia.org
+    api_path:                   /w/api.php
     lang:                       en
     default_project:            en.wikipedia.org
 

--- a/app/config/quote.yml
+++ b/app/config/quote.yml
@@ -477,3 +477,4 @@ parameters:
     - "Yuri Astrakhan: and at the end of the day, there is no such thing as a perfect \"idiot-proof\" way, simply because there are a lot of brilliant idiots."
     - "git #e707717d - Code wars: the empire strikes tap"
     - "<marktraceur> James_F: Reading the policy would restrict me from being able to bend it to my will <James_F> marktraceur: Spoken like a true Wikimedian."
+    - "<musikanimal> oh yeah, recent changes are yummy"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,6 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e425d4ac2fd749ee2f72a92d0b5d1223",
     "content-hash": "25f376424af687a3ff3c91a8f6b26505",
     "packages": [
         {
@@ -54,20 +53,20 @@
             "keywords": [
                 "mediawiki"
             ],
-            "time": "2017-03-08 14:33:42"
+            "time": "2017-03-08T14:33:42+00:00"
         },
         {
             "name": "addwiki/mediawiki-api-base",
-            "version": "2.2.1",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/addwiki/mediawiki-api-base.git",
-                "reference": "a03e58b6806d2e141744dd4a668116ca4f9b141e"
+                "reference": "6416e680011462dd4d01ff9086b0c2f44afa3b20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/addwiki/mediawiki-api-base/zipball/a03e58b6806d2e141744dd4a668116ca4f9b141e",
-                "reference": "a03e58b6806d2e141744dd4a668116ca4f9b141e",
+                "url": "https://api.github.com/repos/addwiki/mediawiki-api-base/zipball/6416e680011462dd4d01ff9086b0c2f44afa3b20",
+                "reference": "6416e680011462dd4d01ff9086b0c2f44afa3b20",
                 "shasum": ""
             },
             "require": {
@@ -76,10 +75,17 @@
                 "php": ">=5.5",
                 "psr/log": "~1.0"
             },
+            "require-dev": {
+                "jakub-onderka/php-parallel-lint": "0.9.2",
+                "phpunit/phpunit": "~4.8.0|~5.3.0"
+            },
+            "suggest": {
+                "etsy/phan": "Allows running static analysis on the package (requires PHP 7+)"
+            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "2.3.x-dev"
                 }
             },
             "autoload": {
@@ -96,11 +102,11 @@
                     "name": "Addshore"
                 }
             ],
-            "description": "A basic Mediawiki api base lib",
+            "description": "A basic Mediawiki api base library",
             "keywords": [
                 "mediawiki"
             ],
-            "time": "2016-08-03 18:24:14"
+            "time": "2017-04-27T15:49:05+00:00"
         },
         {
             "name": "addwiki/mediawiki-datamodel",
@@ -140,7 +146,7 @@
             "keywords": [
                 "mediawiki"
             ],
-            "time": "2017-03-08 13:57:59"
+            "time": "2017-03-08T13:57:59+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -199,7 +205,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-03-06 11:59:08"
+            "time": "2017-03-06T11:59:08+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -267,7 +273,7 @@
                 "docblock",
                 "parser"
             ],
-            "time": "2015-08-31 12:32:49"
+            "time": "2015-08-31T12:32:49+00:00"
         },
         {
             "name": "doctrine/cache",
@@ -337,7 +343,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-10-29 11:16:17"
+            "time": "2016-10-29T11:16:17+00:00"
         },
         {
             "name": "doctrine/collections",
@@ -403,7 +409,7 @@
                 "collections",
                 "iterator"
             ],
-            "time": "2015-04-14 22:21:58"
+            "time": "2015-04-14T22:21:58+00:00"
         },
         {
             "name": "doctrine/common",
@@ -476,7 +482,7 @@
                 "persistence",
                 "spl"
             ],
-            "time": "2016-11-30 16:50:46"
+            "time": "2016-11-30T16:50:46+00:00"
         },
         {
             "name": "doctrine/dbal",
@@ -547,7 +553,7 @@
                 "persistence",
                 "queryobject"
             ],
-            "time": "2017-02-08 12:53:47"
+            "time": "2017-02-08T12:53:47+00:00"
         },
         {
             "name": "doctrine/doctrine-bundle",
@@ -628,7 +634,7 @@
                 "orm",
                 "persistence"
             ],
-            "time": "2017-01-16 12:01:26"
+            "time": "2017-01-16T12:01:26+00:00"
         },
         {
             "name": "doctrine/doctrine-cache-bundle",
@@ -716,7 +722,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2016-01-26 17:28:51"
+            "time": "2016-01-26T17:28:51+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -783,7 +789,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2015-11-06 14:35:42"
+            "time": "2015-11-06T14:35:42+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -837,7 +843,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -891,7 +897,7 @@
                 "lexer",
                 "parser"
             ],
-            "time": "2014-09-09 13:34:57"
+            "time": "2014-09-09T13:34:57+00:00"
         },
         {
             "name": "doctrine/orm",
@@ -967,7 +973,7 @@
                 "database",
                 "orm"
             ],
-            "time": "2016-12-18 15:42:34"
+            "time": "2016-12-18T15:42:34+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",
@@ -1064,7 +1070,7 @@
             "keywords": [
                 "rest"
             ],
-            "time": "2016-11-23 12:09:05"
+            "time": "2016-11-23T12:09:05+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -1126,7 +1132,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2017-02-28 22:50:30"
+            "time": "2017-02-28T22:50:30+00:00"
         },
         {
             "name": "guzzlehttp/promises",
@@ -1177,7 +1183,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2016-12-20 10:07:11"
+            "time": "2016-12-20T10:07:11+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1242,7 +1248,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20 17:10:46"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "incenteev/composer-parameter-handler",
@@ -1293,7 +1299,7 @@
             "keywords": [
                 "parameters management"
             ],
-            "time": "2015-11-10 17:04:01"
+            "time": "2015-11-10T17:04:01+00:00"
         },
         {
             "name": "jdorn/sql-formatter",
@@ -1343,7 +1349,7 @@
                 "highlight",
                 "sql"
             ],
-            "time": "2014-01-12 16:20:24"
+            "time": "2014-01-12T16:20:24+00:00"
         },
         {
             "name": "jms/metadata",
@@ -1394,7 +1400,7 @@
                 "xml",
                 "yaml"
             ],
-            "time": "2016-12-05 10:18:33"
+            "time": "2016-12-05T10:18:33+00:00"
         },
         {
             "name": "jms/parser-lib",
@@ -1429,7 +1435,7 @@
                 "Apache2"
             ],
             "description": "A library for easily creating recursive-descent parsers.",
-            "time": "2012-11-18 18:08:43"
+            "time": "2012-11-18T18:08:43+00:00"
         },
         {
             "name": "jms/serializer",
@@ -1508,7 +1514,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-04-17 15:27:46"
+            "time": "2017-04-17T15:27:46+00:00"
         },
         {
             "name": "jms/serializer-bundle",
@@ -1580,7 +1586,7 @@
                 "serialization",
                 "xml"
             ],
-            "time": "2017-04-10 12:31:39"
+            "time": "2017-04-10T12:31:39+00:00"
         },
         {
             "name": "krinkle/intuition",
@@ -1617,7 +1623,7 @@
                 "CC-BY-3.0"
             ],
             "description": "Framework for localisation in PHP.",
-            "time": "2016-03-16 22:52:37"
+            "time": "2016-03-16T22:52:37+00:00"
         },
         {
             "name": "krinkle/toollabs-base",
@@ -1652,7 +1658,7 @@
                 "Unlicense"
             ],
             "description": "Framework for web apps in Wikimedia's Tool Labs environment.",
-            "time": "2015-09-12 21:24:58"
+            "time": "2015-09-12T21:24:58+00:00"
         },
         {
             "name": "kriswallsmith/assetic",
@@ -1729,7 +1735,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2016-11-11 18:43:20"
+            "time": "2016-11-11T18:43:20+00:00"
         },
         {
             "name": "leafo/scssphp",
@@ -1782,7 +1788,7 @@
                 "scss",
                 "stylesheet"
             ],
-            "time": "2017-02-23 05:07:33"
+            "time": "2017-02-23T05:07:33+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -1860,20 +1866,20 @@
                 "logging",
                 "psr-3"
             ],
-            "time": "2017-03-13 07:08:03"
+            "time": "2017-03-13T07:08:03+00:00"
         },
         {
             "name": "nelmio/cors-bundle",
-            "version": "1.5.1",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nelmio/NelmioCorsBundle.git",
-                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29"
+                "reference": "ac6576a599d7db9c2c6022602c188a5594216056"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/cc9a26517b65769e6e3cea10099d4a40ce11ca29",
-                "reference": "cc9a26517b65769e6e3cea10099d4a40ce11ca29",
+                "url": "https://api.github.com/repos/nelmio/NelmioCorsBundle/zipball/ac6576a599d7db9c2c6022602c188a5594216056",
+                "reference": "ac6576a599d7db9c2c6022602c188a5594216056",
                 "shasum": ""
             },
             "require": {
@@ -1917,7 +1923,7 @@
                 "cors",
                 "crossdomain"
             ],
-            "time": "2017-01-22 21:34:09"
+            "time": "2017-04-24T09:12:42+00:00"
         },
         {
             "name": "nnnick/chartjs",
@@ -1958,7 +1964,7 @@
                 "JS",
                 "chart"
             ],
-            "time": "2017-02-08 20:25:55"
+            "time": "2017-02-08T20:25:55+00:00"
         },
         {
             "name": "paragonie/random_compat",
@@ -2006,7 +2012,7 @@
                 "pseudorandom",
                 "random"
             ],
-            "time": "2017-03-13 16:27:32"
+            "time": "2017-03-13T16:27:32+00:00"
         },
         {
             "name": "phpcollection/phpcollection",
@@ -2054,7 +2060,7 @@
                 "sequence",
                 "set"
             ],
-            "time": "2015-05-17 12:39:23"
+            "time": "2015-05-17T12:39:23+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -2104,7 +2110,7 @@
                 "php",
                 "type"
             ],
-            "time": "2015-07-25 16:39:46"
+            "time": "2015-07-25T16:39:46+00:00"
         },
         {
             "name": "predis/predis",
@@ -2154,7 +2160,7 @@
                 "predis",
                 "redis"
             ],
-            "time": "2016-06-16 16:22:20"
+            "time": "2016-06-16T16:22:20+00:00"
         },
         {
             "name": "psr/cache",
@@ -2200,7 +2206,7 @@
                 "psr",
                 "psr-6"
             ],
-            "time": "2016-08-06 20:24:11"
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2250,7 +2256,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2297,20 +2303,20 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "sensio/distribution-bundle",
-            "version": "v5.0.18",
+            "version": "v5.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sensiolabs/SensioDistributionBundle.git",
-                "reference": "17846680901003d26d823c2e3ac9228702837916"
+                "reference": "654c4fa3d11448c8005400a244987896243a990a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/17846680901003d26d823c2e3ac9228702837916",
-                "reference": "17846680901003d26d823c2e3ac9228702837916",
+                "url": "https://api.github.com/repos/sensiolabs/SensioDistributionBundle/zipball/654c4fa3d11448c8005400a244987896243a990a",
+                "reference": "654c4fa3d11448c8005400a244987896243a990a",
                 "shasum": ""
             },
             "require": {
@@ -2349,7 +2355,7 @@
                 "configuration",
                 "distribution"
             ],
-            "time": "2017-01-10 14:58:45"
+            "time": "2017-04-23T22:28:23+00:00"
         },
         {
             "name": "sensio/framework-extra-bundle",
@@ -2419,7 +2425,7 @@
                 "annotations",
                 "controllers"
             ],
-            "time": "2017-03-21 23:34:44"
+            "time": "2017-03-21T23:34:44+00:00"
         },
         {
             "name": "sensiolabs/security-checker",
@@ -2464,7 +2470,7 @@
                 }
             ],
             "description": "A security checker for your composer.lock",
-            "time": "2017-03-31 14:50:32"
+            "time": "2017-03-31T14:50:32+00:00"
         },
         {
             "name": "snc/redis-bundle",
@@ -2529,20 +2535,20 @@
                 "redis",
                 "symfony"
             ],
-            "time": "2017-02-16 12:02:10"
+            "time": "2017-02-16T12:02:10+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
-            "version": "v5.4.6",
+            "version": "v5.4.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/swiftmailer/swiftmailer.git",
-                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e"
+                "reference": "56db4ed32a6d5c9824c3ecc1d2e538f663f47eb4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
-                "reference": "81fdccfaf8bdc5d5d7a1ef6bb3a61bbb1a6c4a3e",
+                "url": "https://api.github.com/repos/swiftmailer/swiftmailer/zipball/56db4ed32a6d5c9824c3ecc1d2e538f663f47eb4",
+                "reference": "56db4ed32a6d5c9824c3ecc1d2e538f663f47eb4",
                 "shasum": ""
             },
             "require": {
@@ -2583,7 +2589,7 @@
                 "mail",
                 "mailer"
             ],
-            "time": "2017-02-13 07:52:53"
+            "time": "2017-04-20T17:32:18+00:00"
         },
         {
             "name": "symfony/assetic-bundle",
@@ -2653,7 +2659,7 @@
                 "compression",
                 "minification"
             ],
-            "time": "2016-11-22 11:42:57"
+            "time": "2016-11-22T11:42:57+00:00"
         },
         {
             "name": "symfony/monolog-bundle",
@@ -2713,7 +2719,7 @@
                 "log",
                 "logging"
             ],
-            "time": "2017-01-02 19:04:26"
+            "time": "2017-01-02T19:04:26+00:00"
         },
         {
             "name": "symfony/polyfill-intl-icu",
@@ -2771,7 +2777,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -2830,7 +2836,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php56",
@@ -2886,7 +2892,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-php70",
@@ -2945,7 +2951,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-util",
@@ -2997,7 +3003,7 @@
                 "polyfill",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/swiftmailer-bundle",
@@ -3056,7 +3062,7 @@
             ],
             "description": "Symfony SwiftmailerBundle",
             "homepage": "http://symfony.com",
-            "time": "2017-03-21 21:47:36"
+            "time": "2017-03-21T21:47:36+00:00"
         },
         {
             "name": "symfony/symfony",
@@ -3200,7 +3206,7 @@
             "keywords": [
                 "framework"
             ],
-            "time": "2017-04-05 12:52:29"
+            "time": "2017-04-05T12:52:29+00:00"
         },
         {
             "name": "twbs/bootstrap",
@@ -3251,20 +3257,20 @@
                 "responsive",
                 "web"
             ],
-            "time": "2016-07-25 15:51:55"
+            "time": "2016-07-25T15:51:55+00:00"
         },
         {
             "name": "twig/twig",
-            "version": "v1.33.0",
+            "version": "v1.33.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a"
+                "reference": "dd6ca96227917e1e85b41c7c3cc6507b411e0927"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a",
-                "reference": "05cf49921b13f6f01d3cfdf9018cfa7a8086fd5a",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/dd6ca96227917e1e85b41c7c3cc6507b411e0927",
+                "reference": "dd6ca96227917e1e85b41c7c3cc6507b411e0927",
                 "shasum": ""
             },
             "require": {
@@ -3313,7 +3319,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-03-22 15:40:09"
+            "time": "2017-04-20T17:39:48+00:00"
         },
         {
             "name": "willdurand/jsonp-callback-validator",
@@ -3353,7 +3359,7 @@
                 }
             ],
             "description": "JSONP callback validator.",
-            "time": "2014-01-20 22:35:06"
+            "time": "2014-01-20T22:35:06+00:00"
         },
         {
             "name": "willdurand/negotiation",
@@ -3405,7 +3411,7 @@
                 "header",
                 "negotiation"
             ],
-            "time": "2016-10-14 09:17:47"
+            "time": "2016-10-14T09:17:47+00:00"
         }
     ],
     "packages-dev": [
@@ -3454,7 +3460,7 @@
             ],
             "description": "This tool check syntax of PHP files about 20x faster than serial check.",
             "homepage": "https://github.com/JakubOnderka/PHP-Parallel-Lint",
-            "time": "2015-12-15 10:42:16"
+            "time": "2015-12-15T10:42:16+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3508,7 +3514,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3553,7 +3559,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2016-09-30 07:12:33"
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -3600,7 +3606,7 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2016-11-25 06:54:22"
+            "time": "2016-11-25T06:54:22+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -3663,7 +3669,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-03-02 20:05:34"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3725,7 +3731,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2015-10-06T15:47:00+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3772,7 +3778,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2016-10-03 07:40:28"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -3813,7 +3819,7 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
@@ -3862,7 +3868,7 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26 11:10:40"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
@@ -3911,7 +3917,7 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-02-27 10:12:30"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -3983,7 +3989,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-02-06 05:18:07"
+            "time": "2017-02-06T05:18:07+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -4039,7 +4045,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2015-10-02T06:51:40+00:00"
         },
         {
             "name": "sebastian/comparator",
@@ -4103,7 +4109,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2017-01-29 09:50:25"
+            "time": "2017-01-29T09:50:25+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -4155,7 +4161,7 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4205,7 +4211,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-08-18 05:49:44"
+            "time": "2016-08-18T05:49:44+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4272,7 +4278,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2016-06-17 09:04:28"
+            "time": "2016-06-17T09:04:28+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -4323,7 +4329,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
             "name": "sebastian/recursion-context",
@@ -4376,7 +4382,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2016-10-03 07:41:43"
+            "time": "2016-10-03T07:41:43+00:00"
         },
         {
             "name": "sebastian/version",
@@ -4411,7 +4417,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2015-06-21T13:59:46+00:00"
         },
         {
             "name": "sensio/generator-bundle",
@@ -4465,7 +4471,7 @@
                 }
             ],
             "description": "This bundle generates code for you",
-            "time": "2017-03-15 01:02:10"
+            "time": "2017-03-15T01:02:10+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -4543,7 +4549,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01 22:17:45"
+            "time": "2017-03-01T22:17:45+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",
@@ -4605,7 +4611,7 @@
             ],
             "description": "Symfony PHPUnit Bridge",
             "homepage": "https://symfony.com",
-            "time": "2017-03-09 12:58:16"
+            "time": "2017-03-09T12:58:16+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -4655,7 +4661,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:58"
+            "time": "2016-11-23T20:04:58+00:00"
         }
     ],
     "aliases": [],

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -47,3 +47,4 @@ of those options.
 - **app.single_wiki** - Point xTools to a single wiki, instead of using a meta database.  This ignores database_meta_name above.
 - **app.is_labs** - Whether xTools lives on the Wikimedia Foundation Labs environment.  This should be set to false.
 - **wiki_url** - URL to use if app.single_wiki is enabled.  The title of pages is attached to the end.
+- **api_path** - The API path for the project, usually /w/api.php

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ To install xTools, please follow these steps:
 
 1. Download the repository into a web-accessible location.
 2. Ensure that ``var/`` and all files within it (other than ``var/SymfonyRequirements.php``) are writable by the web server.
-3. Run ``composer install`` and be prompted to enter database details and other configuration information. 
+3. Run ``composer install`` and be prompted to enter database details and other configuration information.
 4. Open xTools in your browser; you should see the xTools landing page.
 
 To update the cache after making configuration changes, run ``./bin/console cache:clear``.
@@ -18,6 +18,7 @@ To use xTools for a single wiki, set the following variables in ``parameters.yml
 
 * ``app.single_wiki`` to ``true``
 * ``wiki_url`` to the full URL of your wiki
+* ``api_path`` to the path to the root of your wiki's API
 
 Wiki family
 ===========

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -80,6 +80,7 @@
   "importance": "Importance",
   "interrupted": "Sorry, but in order to save resources, a bot has automatically killed this query for being longer than $1 seconds.",
   "invalid_date": "Invalid date",
+  "invalid_project": "$1 is not a valid project",
   "invalid_type": "Invalid type selected",
   "ip_edits": "IP edits",
   "ip_list": "IP list",

--- a/tests/AppBundle/Helper/ApiHelperTest.php
+++ b/tests/AppBundle/Helper/ApiHelperTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\AppBundle\Helper;
+
+use AppBundle\Helper\ApiHelper;
+use AppBundle\Helper\LabsHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+class ApiHelperTest extends WebTestCase
+{
+
+    /** @var Container */
+    protected $container;
+
+    /** @var ApiHelper */
+    protected $apiHelper;
+
+    public function setUp()
+    {
+        $client = static::createClient();
+        $this->container = $client->getContainer();
+        $labsHelper = new LabsHelper($this->container);
+        $this->apiHelper = new ApiHelper($this->container, $labsHelper);
+        $this->cache = $this->container->get('cache.app');
+    }
+
+    public function testSiteInfo()
+    {
+        if ($this->container->getParameter('app.is_labs')) {
+            $siteInfo = $this->apiHelper->getSiteInfo('enwiki');
+            $this->assertEquals($siteInfo['general']['articlePath'], '/wiki/$1');
+        }
+    }
+
+    public function testNamespaces()
+    {
+        if ($this->container->getParameter('app.is_labs')) {
+            $namespaces = $this->apiHelper->namespaces('enwiki');
+            $this->assertEquals($namespaces['1'], 'Talk');
+            $this->assertEquals($namespaces['2'], 'User');
+        }
+    }
+}

--- a/tests/AppBundle/Helper/LabsHelperTest.php
+++ b/tests/AppBundle/Helper/LabsHelperTest.php
@@ -34,4 +34,24 @@ class LabsHelperTest extends WebTestCase
             $this->assertEquals('logging', $this->labsHelper->getTable('logging'));
         }
     }
+
+    public function testDatabasePrepare()
+    {
+        if ($this->container->getParameter('app.is_labs')) {
+            // When using Labs.
+            $dbVales = $this->labsHelper->databasePrepare('en.wikipedia');
+            $this->assertEquals('enwiki', $dbVales['dbName']);
+            $this->assertEquals('https://en.wikipedia.org', $dbVales['url']);
+        }
+    }
+
+    public function testNormalizeProject()
+    {
+        if ($this->container->getParameter('app.is_labs')) {
+            // When using Labs.
+            $this->assertEquals('en.wikipedia.org', $this->labsHelper->normalizeProject('enwiki'));
+            $this->assertEquals('en.wikipedia.org', $this->labsHelper->normalizeProject('en.wikipedia'));
+            $this->assertEquals(false, $this->labsHelper->normalizeProject('invalid.wiki'));
+        }
+    }
 }

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -215,7 +215,7 @@
                 // FIXME: i18n
                 $('.site-notice').append(
                     "<div class='alert alert-warning alert-dismissible' role='alert'>" +
-                        "<a href='//" + newProject.escape() + "'>" + newProject + "</a> is not a valid project." +
+                        $.i18n('invalid_project', "<strong>" + newProject + "</strong>") +
                         "<button class='close' data-dismiss='alert' aria-label='Close'>" +
                             "<span aria-hidden='true'>&times;</span>" +
                         "</button>" +


### PR DESCRIPTION
to get metadata about a project, and cache it

Major refactoring of fetching metadata about a project, including namespaces

New 'normalizeProject' to get lang.project.org from various formats

Some i18n fixes

Fun addition to bash quotes

Bug: T163634