### PR TITLE
Clarify database pre-requesites

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,6 +20,8 @@ To use xTools for a single wiki, set the following variables in ``parameters.yml
 * ``wiki_url`` to the full URL of your wiki
 * ``api_path`` to the path to the root of your wiki's API
 
+.. _wiki-family-installation:
+
 Wiki family
 ===========
 

--- a/docs/pre-requisites.rst
+++ b/docs/pre-requisites.rst
@@ -17,13 +17,12 @@ Xtools requires the following to run:
 Databases
 ---------
 
-1. A main tool database.  This just needs to be created, and the xTools user needs create and destroy privilages.
-2. One or more project databases.  This should be a current mediawiki install.  The meta database should point to it.
+1. One or more project databases.  These should be current mediawiki installations.  The meta database should point to them.
+2. A Meta database.
+   If you are running more than one wiki (``app.is_single_wiki`` set to false), information on each wiki must be stored in a meta database.
+   xTools uses one modeled after `The WMF Labs database. <https://wikitech.wikimedia.org/wiki/Help:MySQL_queries#meta_p_database>`_.
 
-Optional Database
------------------
-If you are running more than one wiki (app.is_single_wiki set to false), information on each wiki must be stored in a meta database.  xTools uses one modeled after `The WMF Labs database. <https://wikitech.wikimedia.org/wiki/Help:MySQL_queries#meta_p_database>`_.
+   This database must live on the same machine as the project databases.
 
-This database must live on the same machine as the project databases.
-
-Run ``sql/meta.sql``  to set one up.
+   See the :ref:`installation documentation <wiki-family-installation>` for more details if you don't already have this database available.
+3. An optional Tools' database, where other MediaWiki tools store their data.


### PR DESCRIPTION
Remove reference to sql/meta.sql as that's no longer present,
and instead link to installation instructions for that table.

Also mention Tools' DB.

Bug: https://phabricator.wikimedia.org/T164127