### PR TITLE
EditCounter: Rework avg/small/larges and compute only against past 5000 edits

### DIFF
--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -89,7 +89,7 @@
         <tr><td>{{ msg('last-month') }}</td><td>{{ ec.countRevisionsInLast('month')|number_format }}</td></tr>
         <tr><td>{{ msg('last-year') }}</td><td>{{ ec.countRevisionsInLast('year')|number_format }}</td></tr>
         <tr>
-            <td>{{ msg("average-edits-per-day", [msg("days", [1])]) }}</td>
+            <td>{{ msg('average-edits-per-day', [msg('days', [1])]) }}</td>
             <td>
                 {{ ec.averageRevisionsPerDay|number_format(1) }}
                 <span class="text-muted">
@@ -98,8 +98,8 @@
             </td>
         </tr>
         <tr>
-            <td>{{ msg('average-edit-size') }}</td>
-            <td>{{ ec.averageRevisionSize|number_format(1) }}</td>
+            <td>{{ msg('average-edit-size') }}*</td>
+            <td>{{ ec.averageEditSize|number_format(1) }} {{ msg('num-bytes', [ec.averageEditSize]) }}</td>
         </tr>
     </tbody></table>
 </div>
@@ -202,19 +202,19 @@
                 </td>
             </tr>
             <tr>
-                <td>{{ msg('small-edits') }}</td>
+                <td>{{ msg('small-edits') }}*</td>
                 <td>
-                    {{ ec.countSmallRevisions|number_format }}
+                    {{ ec.countSmallEdits|number_format }}
                     &middot;
-                    ({{ ((ec.countSmallRevisions / ec.countLiveRevisions) * 100)|percent_format }})
+                    ({{ ((ec.countSmallEdits / ec.countLast5000) * 100)|percent_format }})
                 </td>
             </tr>
             <tr>
-                <td>{{ msg('large-edits') }}</td>
+                <td>{{ msg('large-edits') }}*</td>
                 <td>
-                    {{ ec.countLargeRevisions|number_format }}
+                    {{ ec.countLargeEdits|number_format }}
                     &middot;
-                    ({{ ((ec.countLargeRevisions / ec.countLiveRevisions) * 100)|percent_format }})
+                    ({{ ((ec.countLargeEdits / ec.countLast5000) * 100)|percent_format }})
                 </td>
             </tr>
         </tbody>
@@ -423,31 +423,34 @@
     {{
         chart.pie_chart('small_edits',
             [{
-                label: '< 20 ' ~ msg('num-bytes', [20]),
-                value: ec.countSmallRevisions,
-                percentage: ((ec.countSmallRevisions / ec.countLiveRevisions) * 100)
+                label: '< 20 ' ~ msg('num-bytes', [20]) ~ '*',
+                value: ec.countSmallEdits,
+                percentage: ((ec.countSmallEdits / ec.countLast5000) * 100)
             },
             {
-                label: '≥ 20 ' ~ msg('num-bytes', [20]),
-                value: ec.countLiveRevisions - ec.countSmallRevisions,
-                percentage: 100 - ((ec.countSmallRevisions / ec.countLiveRevisions) * 100)
+                label: '≥ 20 ' ~ msg('num-bytes', [20]) ~ '*',
+                value: ec.countLast5000 - ec.countSmallEdits,
+                percentage: 100 - ((ec.countSmallEdits / ec.countLast5000) * 100)
             }]
         )
     }}
     {{
         chart.pie_chart('large_edits',
             [{
-                label: '< 1000 ' ~ msg('num-bytes', [1000]),
-                value: ec.countLargeRevisions,
-                percentage: ((ec.countLargeRevisions / ec.countLiveRevisions) * 100)
+                label: '< 1000 ' ~ msg('num-bytes', [1000]) ~ '*',
+                value: ec.countLargeEdits,
+                percentage: ((ec.countLargeEdits / ec.countLast5000) * 100)
             },
             {
-                label: '≥ 1000 ' ~ msg('num-bytes', [1000]),
-                value: ec.countLiveRevisions - ec.countLargeRevisions,
-                percentage: 100 - ((ec.countLargeRevisions / ec.countLiveRevisions) * 100)
+                label: '≥ 1000 ' ~ msg('num-bytes', [1000]) ~ '*',
+                value: ec.countLast5000 - ec.countLargeEdits,
+                percentage: 100 - ((ec.countLargeEdits / ec.countLast5000) * 100)
             }]
         )
     }}
+    <div class="footnotes">
+        * {{ msg('data-limit', [5000, 5000|number_format]) }}
+    </div>
 </div>
 
 {% if not is_sub_request %}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -55,6 +55,7 @@
   "created-by": "Created by",
   "current-admins": "Current admins",
   "current-size": "Current size",
+  "data-limit": "Data limited to the past $2 {{PLURAL:$1|edit|edits}}",
   "date": "Date",
   "delete": "Delete",
   "deleted": "Deleted",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -54,6 +54,7 @@
   "created-by": "Created by",
   "current-admins": "Label for the current number of admins for a project.",
   "current-size": "Indicates the current size of a page.\n{{Identical|Current size}}",
+  "data-limit": "Footnote indictaing that data only accounts for the past $1 edits the user has made. $1 is the raw number that can be used in {{PLURAL}}, and $2 is the formatted number.",
   "date": "Label for a date field\n{{Identical|Date}}",
   "delete": "Name of a MediaWiki log action, used as header of a row in the table of log action counts for a user.\n{{Identical|Delete}}",
   "deleted": "Deleted in the context of deleted text or deleted edits.\n{{Identical|Deleted}}",

--- a/web/static/css/editcounter.scss
+++ b/web/static/css/editcounter.scss
@@ -42,4 +42,9 @@
             }
         }
     }
+
+    .footnotes {
+        clear: both;
+        padding-top: 20px;
+    }
 }


### PR DESCRIPTION
Alternative solution to https://phabricator.wikimedia.org/T170103

I did not write tests because the testable functions do nothing more than reference what the Repo returns.