### PR TITLE
Treat pages with invalid title as nonexistent

### DIFF
--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -127,7 +127,7 @@ class ArticleInfoController extends Controller
         $page->setRepository($pageRepo);
 
         if (!$page->exists()) {
-            $this->addFlash('notice', ['no-exist', $pageQuery]);
+            $this->addFlash('notice', ['no-exist', str_replace('_', ' ', $pageQuery)]);
             return $this->redirectToRoute('articleInfo');
         }
 

--- a/src/Xtools/Page.php
+++ b/src/Xtools/Page.php
@@ -128,7 +128,7 @@ class Page extends Model
     public function exists()
     {
         $info = $this->getPageInfo();
-        return !isset($info['missing']);
+        return !isset($info['missing']) && !isset($info['invalid']);
     }
 
     /**


### PR DESCRIPTION
E.g. see http://xtools.wmflabs.org/articleinfo/en.wikipedia.org/2017_NCAA_Division_I_Women%252527s_Basketball_Tournament

The MediaWiki API returns https://en.wikipedia.org/w/api.php?action=query&prop=info|pageprops&titles=2017_NCAA_Division_I_Women%2527s_Basketball_Tournament which does include `missing`, so XTools thinks it's valid.