### PR TITLE
ArticleInfo: fix to use new Edit::isRevert and Edit::getTool

### DIFF
--- a/app/config/semi_automated.yml
+++ b/app/config/semi_automated.yml
@@ -1,19 +1,57 @@
 # If you change the key names, do a find/replace to update their usage throughout the rest of XTools
+#
+# Format for individual entries:
+#
+#   Tool name:
+#       regex: Regular expression to match against edit summary
+#       tag: Tag name for the tool, if applicable. See [[Special:Tags]] for full list
+#       link: Wiki link to tool documentation
+#       revert: If the tool is used *only* to revert edits (and not also issue talk page
+#               notifications, etc.), set this to `true`. If the tool is capable of reverting
+#               edits, set 'revert' to regex that would only account for reverts.
+#               See the 'Twinkle' entry for an example. The revert-only regex is necessary
+#               for ArticleInfo and elsewhere, so as to differentiate edits that added content
+#               from edits that restored content.
+#
+# Either 'regex' or 'tag' are required. In some cases you might want to include both,
+#   say if older versions of the tool did not add tags to the edits.
 parameters:
   automated_tools:
+
+    # These tools work on multiple wikis. These should probably include tags
+    #   as the regex may not apply to non-English wikis.
+    # You can also set wiki-specific values that will get merged into the global one.
+    # See 'Hugge' under 'global' and 'en.wikipedia.org' for an example.
+    global:
+        Huggle:
+            regex: '\(\[\[WP:HG'
+            tag: huggle
+            link: w:en:Wikipedia:Huggle
+        WPCleaner:
+            regex: 'WP:CLEANER|\[\[\Wikipedia:DPL|\[\[WP:WCW\]\] project \('
+            tag: WPCleaner
+            link: Project:WPCleaner
+
+    # Per-wiki lists
     en.wikipedia.org:
         Generic rollback:
             regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) edits by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\] \(\[\[User talk:.*?\|talk\]\]\) to last version by .*'
             link: Project:Rollback
+            revert: true
         Undo:
             regex: '^Undid revision \d+ by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\]'
             link: Project:Undo
+            revert: true
         Pending changes revert:
             regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) \d+ (\[\[Wikipedia:Pending changes\|pending\]\]|pending) edits? (to revision \d+|by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\])'
             link: Project:Pending changes
+            revert: true
         Bot revert:
             regex: '^Reverting possible (vandalism|test edit).*by.*\(Bot|BOT( EDIT)?\)$|^BOT (- )?(Reverted edits? by|rv)|^vandalism from \[\[.*?\(\d+\) - reverted'
             link: Project:Bots
+            revert: true
+        Huggle: # This gets merged into the global Huggle definition (the revert regex here is enwiki-specific)
+            revert: 'Reverted edits by.*?WP:HG'
         Page move:
             regex: '^.*?moved page \[\[(?!.*?WP:AFCH)|moved \[\[.*?\]\] to \[\['
             link: Project:Move
@@ -21,15 +59,13 @@ parameters:
             regex: 'using \[\[Wikipedia:Page Curation\|Page Curation'
             link: Project:Page curation
         Twinkle:
-            regex: 'WP:(TW|TWINKLE|Twinkle)|WP:FRIENDLY|Wikipedia:Twinkle'
+            regex: '(Wikipedia|WP):(TW|TWINKLE|Twinkle|FRIENDLY)'
             link: Project:Twinkle
-        Huggle:
-            regex: 'WP:HG'
-            tag: huggle
-            link: w:en:Wikipedia:Huggle
+            revert: '(Reverted to revision|Reverted \d+ edits).*(WP:(TW|TWINKLE|Twinkle)|Wikipedia:Twinkle)'
         STiki:
-            regex: 'WP:STiki|WP:STIKI'
+            regex: 'WP:(STiki|STIKI)'
             link: w:en:Wikipedia:STiki
+            revert: Reverted \d+.*WP:(STiki|STIKI)
         Igloo:
             regex: 'Wikipedia:Igloo'
             link: w:en:Wikipedia:Igloo
@@ -37,15 +73,11 @@ parameters:
             regex: 'Wikipedia:Tools\/Navigation_popups|popups'
             link: Project:Popups
         AFCH:
-            regex: 'WP:AFCH|WP:AFCHRW'
+            regex: 'WP:(AFCH|AFCHRW)'
             link: Project:AFCH
-        AWB:
-            regex: 'Wikipedia:AWB|WP:AWB|Project:AWB'
+        AutoWikiBrowser:
+            regex: '(Wikipedia|WP|Project):AWB'
             link: Project:AutoWikiBrowser
-        WPCleaner:
-            regex: 'WP:CLEANER|\[\[\Wikipedia:DPL|\[\[WP:WCW\]\] project \('
-            tag: WPCleaner
-            link: Project:WPCleaner
         HotCat:
             regex: 'using \[\[(WP:HOTCAT|WP:HC|Help:Gadget-HotCat)\|HotCat'
             link: Project:HotCat
@@ -53,7 +85,7 @@ parameters:
             regex: 'User:Zhaofeng Li\/Reflinks|WP:REFILL'
             link: Project:ReFill
         Checklinks:
-            regex: 'using \[\[w:WP:CHECKLINKS\|Checklinks'
+            regex: 'using \[\[w:WP:CHECKLINKS'
             link: Project:CHECKLINKS
         Dab solver:
             regex: 'using \[\[(tools:~dispenser\/view\/Dab_solver|WP:DABSOLVER)\|Dab solver|(Disambiguated|Unlinked|Help needed): \[\[|Disambiguated \d+ links|Repaired link.*?\[\[Wikipedia:WikiProject Disambiguation\|please help'
@@ -167,9 +199,6 @@ parameters:
         For the Common Good:
             regex: 'WP:FTCG\|FtCG'
             link: Project:FTCG
-        Twinkle revert:
-            regex: '(Reverted to revision|Reverted \d+ edits).*(WP:(TW|TWINKLE|Twinkle)|Wikipedia:Twinkle)'
-            link: Project:Twinkle
         User:Technical13/Scripts/OrphanStatus.js:
             regex: '\[\[User:Technical_13\/Scripts\/OrphanStatus\|'
             link: User:Technical13/Scripts/OrphanStatus.js

--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -513,7 +513,7 @@ class ArticleInfoController extends Controller
             $data['editors'][$username]['sizes'][] = $edit->getLength() / 1024;
 
             // Check if it was a revert
-            if ($this->aeh->isRevert($edit->getComment())) {
+            if ($edit->isRevert($this->container)) {
                 $data['general']['revert_count']++;
 
                 // Since this was a revert, we don't want to treat the previous
@@ -573,19 +573,19 @@ class ArticleInfoController extends Controller
                 $data['editors'][$username]['minor']++;
             }
 
-            $automatedTool = $this->aeh->getTool($edit->getComment());
+            $automatedTool = $edit->getTool($this->container);
             if ($automatedTool) {
                 $data['general']['automated_count']++;
                 $data['year_count'][$editYear]['automated']++;
                 $data['year_count'][$editYear]['months'][$editMonth]['automated']++;
 
-                if (!isset($data['tools'][$automatedTool])) {
-                    $data['tools'][$automatedTool] = [
+                if (!isset($data['tools'][$automatedTool['name']])) {
+                    $data['tools'][$automatedTool['name']] = [
                         'count' => 1,
-                        'link' => $this->aeh->getTools()[$automatedTool]['link'],
+                        'link' => $automatedTool['link'],
                     ];
                 } else {
-                    $data['tools'][$automatedTool]['count']++;
+                    $data['tools'][$automatedTool['name']]['count']++;
                 }
             }
 

--- a/src/AppBundle/Helper/AutomatedEditsHelper.php
+++ b/src/AppBundle/Helper/AutomatedEditsHelper.php
@@ -5,31 +5,19 @@
 
 namespace AppBundle\Helper;
 
-use DateTime;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Xtools\ProjectRepository;
 
 /**
- * Helper class for getting information about semi-automated edits.
+ * Helper class for fetching semi-automated definitions.
  */
 class AutomatedEditsHelper extends HelperBase
 {
 
     /** @var string[] The list of tools that are considered reverting. */
-    public $revertTools = [
-        'Generic rollback',
-        'Undo',
-        'Pending changes revert',
-        'Huggle',
-        'STiki',
-        'Igloo',
-        'WikiPatroller',
-        'Twinkle revert',
-        'Bot revert'
-    ];
+    protected $revertTools = [];
 
     /** @var string[] The list of tool names and their regexes. */
-    protected $tools;
+    protected $tools = [];
 
     /**
      * AutomatedEditsHelper constructor.
@@ -41,67 +29,118 @@ class AutomatedEditsHelper extends HelperBase
     }
 
     /**
-     * Was the edit (semi-)automated, based on the edit summary?
-     * @param  string  $summary Edit summary
-     * @return boolean          Yes or no
+     * Get the tool that matched the given edit summary.
+     * This only works for tools defined with regular expressions, not tags.
+     * @param  string $summary Edit summary
+     * @param  string $projectDomain Such as en.wikipedia.org
+     * @return string|bool Tool entry including key for 'name', or false if nothing was found
      */
-    public function isAutomated($summary)
+    public function getTool($summary, $projectDomain)
     {
-        foreach ($this->getTools() as $tool => $values) {
-            $regex = $values['regex'];
-            if (preg_match("/$regex/", $summary)) {
-                return true;
+        foreach ($this->getTools($projectDomain) as $tool => $values) {
+            if (isset($values['regex']) && preg_match('/'.$values['regex'].'/', $summary)) {
+                return array_merge([
+                    'name' => $tool,
+                ], $values);
             }
         }
 
         return false;
+    }
+
+    /**
+     * Was the edit (semi-)automated, based on the edit summary?
+     * This only works for tools defined with regular expressions, not tags.
+     * @param  string $summary Edit summary
+     * @param  string $projectDomain Such as en.wikipedia.org
+     * @return bool
+     */
+    public function isAutomated($summary, $projectDomain)
+    {
+        return (bool) $this->getTool($summary, $projectDomain);
+    }
+
+    /**
+     * Get list of automated tools and their associated info for the
+     *   given project. This defaults to the 'default_project' if
+     *   entries for the given project are not found.
+     * @param  string $projectDomain Such as en.wikipedia.org
+     * @return string[] Each tool with the tool name as the key,
+     *   and 'link', 'regex' and/or 'tag' as the subarray keys.
+     */
+    public function getTools($projectDomain)
+    {
+        if (isset($this->tools[$projectDomain])) {
+            return $this->tools[$projectDomain];
+        }
+
+        // Load the semi-automated edit types.
+        $toolsByWiki = $this->container->getParameter('automated_tools');
+
+        // Default to default project (e.g. en.wikipedia.org) if wiki not configured
+        if (isset($toolsByWiki[$projectDomain])) {
+            $this->tools[$projectDomain] = $toolsByWiki[$projectDomain];
+        } else {
+            $this->tools[$projectDomain] = $toolsByWiki[$this->container->getParameter('default_project')];
+        }
+
+        // Merge wiki-specific rules into the global rules
+        $this->tools[$projectDomain] = array_merge_recursive(
+            $toolsByWiki['global'],
+            $this->tools[$projectDomain]
+        );
+
+        return $this->tools[$projectDomain];
+    }
+
+    /**
+     * Get only tools that are used to revert edits.
+     * Revert detection happens only by testing against a regular expression,
+     *   and not by checking tags.
+     * @param  string $projectDomain Such as en.wikipedia.org
+     * @return string Each tool with the tool name as the key,
+     *   and 'link' and 'regex' as the subarray keys.
+     */
+    public function getRevertTools($projectDomain)
+    {
+        if (isset($this->revertTools[$projectDomain])) {
+            return $this->revertTools[$projectDomain];
+        }
+
+        $revertEntries = array_filter(
+            $this->getTools($projectDomain),
+            function ($tool) {
+                return isset($tool['revert']);
+            }
+        );
+
+        // If 'revert' is set to `true`, the use 'regex' as the regular expression,
+        //  otherwise 'revert' is assumed to be the regex string.
+        $this->revertTools[$projectDomain] = array_map(function ($revertTool) {
+            return [
+                'link' => $revertTool['link'],
+                'regex' => $revertTool['revert'] === true ? $revertTool['regex'] : $revertTool['revert']
+            ];
+        }, $revertEntries);
+
+        return $this->revertTools[$projectDomain];
     }
 
     /**
      * Was the edit a revert, based on the edit summary?
+     * This only works for tools defined with regular expressions, not tags.
      * @param  string $summary Edit summary
-     * @return boolean         Yes or no
+     * @param  string $projectDomain Such as en.wikipedia.org
+     * @return bool
      */
-    public function isRevert($summary)
+    public function isRevert($summary, $projectDomain)
     {
-        foreach ($this->revertTools as $tool) {
-            $regex = $this->getTools()[$tool]['regex'];
-
-            if (preg_match("/$regex/", $summary)) {
+        foreach ($this->getRevertTools($projectDomain) as $tool => $values) {
+            if (preg_match('/'.$values['regex'].'/', $summary)) {
                 return true;
             }
         }
 
         return false;
-    }
-
-    /**
-     * Get the name of the tool that matched the given edit summary
-     * @param  string $summary Edit summary
-     * @return string|boolean  Name of tool, or false if nothing was found
-     */
-    public function getTool($summary)
-    {
-        foreach ($this->getTools() as $tool => $values) {
-            $regex = $values['regex'];
-            if (preg_match("/$regex/", $summary)) {
-                return $tool;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Get the list of automated tools
-     * @return array Associative array of 'tool name' => 'regex'
-     */
-    public function getTools()
-    {
-        if (is_array($this->tools)) {
-            return $this->tools;
-        }
-        $this->tools = $this->container->getParameter('automated_tools');
-        return $this->tools;
     }
 }

--- a/src/Xtools/Edit.php
+++ b/src/Xtools/Edit.php
@@ -6,7 +6,7 @@
 namespace Xtools;
 
 use Xtools\User;
-use AppBundle\Helper\AutomatedEditsHelper;
+use Symfony\Component\DependencyInjection\Container;
 use DateTime;
 
 /**
@@ -278,22 +278,34 @@ class Edit extends Model
 
     /**
      * Was the edit a revert, based on the edit summary?
+     * @param Container $container The DI container.
      * @return bool
      */
-    public function isRevert()
+    public function isRevert(Container $container)
     {
-        $automatedEditsHelper = $this->container->get('app.automated_edits_helper');
-        return $automatedEditsHelper->isRevert($this->comment);
+        $automatedEditsHelper = $container->get('app.automated_edits_helper');
+        return $automatedEditsHelper->isRevert($this->comment, $this->getProject()->getDomain());
+    }
+
+    /**
+     * Get the name of the tool that was used to make this edit.
+     * @param Container $container The DI container.
+     * @return string|false The name of the tool that was used to make the edit
+     */
+    public function getTool(Container $container)
+    {
+        $automatedEditsHelper = $container->get('app.automated_edits_helper');
+        return $automatedEditsHelper->getTool($this->comment, $this->getProject()->getDomain());
     }
 
     /**
      * Was the edit (semi-)automated, based on the edit summary?
-     * @return string|false The name of the tool that was used to make the edit
+     * @param  Container $container [description]
+     * @return bool
      */
-    public function isAutomated()
+    public function isAutomated(Container $container)
     {
-        $automatedEditsHelper = $this->container->get('app.automated_edits_helper');
-        return $automatedEditsHelper->getTool($this->comment);
+        return (bool) $this->getTool($container);
     }
 
     /**

--- a/src/Xtools/UserRepository.php
+++ b/src/Xtools/UserRepository.php
@@ -575,7 +575,8 @@ class UserRepository extends Repository
         $conn = $this->getProjectsConnection();
 
         // Load the semi-automated edit types.
-        $tools = $this->getTools($project->getDomain());
+        $automatedEditsHelper = $this->container->get('app.automated_edits_helper');
+        $tools = $automatedEditsHelper->getTools($project->getDomain());
 
         // Create a collection of queries that we're going to run.
         $queries = [];
@@ -691,27 +692,6 @@ class UserRepository extends Repository
     }
 
     /**
-     * Get list of automated tools and their associated info for the
-     *   given project. This defaults to the 'default_project' if
-     *   entries for the given project are not found.
-     * @param  string $projectDomain Such as en.wikipedia.org
-     * @return string[] Each tool with the tool name as the key,
-     *   and 'link', 'regex' or 'tag' as the subarray keys.
-     */
-    private function getTools($projectDomain)
-    {
-        // Load the semi-automated edit types.
-        $toolsByWiki = $this->container->getParameter('automated_tools');
-
-        // Default to default project (e.g. enwiki) if wiki not configured
-        if (isset($toolsByWiki[$projectDomain])) {
-            return $toolsByWiki[$projectDomain];
-        } else {
-            return $toolsByWiki[$this->container->getParameter('default_project')];
-        }
-    }
-
-    /**
      * Get the combined regex and tags for all semi-automated tools,
      *   ready to be used in a query.
      * @param string $projectDomain Such as en.wikipedia.org
@@ -721,7 +701,8 @@ class UserRepository extends Repository
      */
     private function getToolRegexAndTags($projectDomain, $conn)
     {
-        $tools = $this->getTools($projectDomain);
+        $automatedEditsHelper = $this->container->get('app.automated_edits_helper');
+        $tools = $automatedEditsHelper->getTools($projectDomain);
         $regexes = [];
         $tags = [];
         foreach ($tools as $tool => $values) {

--- a/tests/AppBundle/Helper/AutomatedEditsTest.php
+++ b/tests/AppBundle/Helper/AutomatedEditsTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * This file contains tests for the AutomatedEditsHelper class.
+ */
+
+namespace Tests\AppBundle\Helper;
+
+use AppBundle\Helper\AutomatedEditsHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\DependencyInjection\Container;
+
+/**
+ * Tests of the AutomatedEditsHelper class.
+ * @group integration
+ */
+class AutomatedEditsTest extends WebTestCase
+{
+    /** @var Container The DI container. */
+    protected $container;
+
+    /** @var AutomatedEditsHelper The API Helper object to test. */
+    protected $aeh;
+
+    /**
+     * Set up the AutomatedEditsHelper object for testing.
+     */
+    public function setUp()
+    {
+        $client = static::createClient();
+        $this->container = $client->getContainer();
+        $this->aeh = new AutomatedEditsHelper($this->container);
+        $this->cache = $this->container->get('cache.app');
+    }
+
+    /**
+     * Test that the merge of per-wiki config and global config works
+     */
+    public function testTools()
+    {
+        $tools = $this->aeh->getTools('en.wikipedia.org');
+
+        $this->assertArraySubset(
+            [
+                'regex' => '\(\[\[WP:HG',
+                'tag' => 'huggle',
+                'link' => 'w:en:Wikipedia:Huggle',
+                'revert' => 'Reverted edits by.*?WP:HG',
+            ],
+            $tools['Huggle']
+        );
+
+        $this->assertEquals(1, array_count_values(array_keys($tools))['Huggle']);
+    }
+
+    /**
+     * Make sure the right tool is detected
+     */
+    public function testTool()
+    {
+        $this->assertArraySubset(
+            [
+                'name' => 'Huggle',
+                'regex' => '\(\[\[WP:HG',
+                'tag' => 'huggle',
+                'link' => 'w:en:Wikipedia:Huggle',
+                'revert' => 'Reverted edits by.*?WP:HG',
+            ],
+            $this->aeh->getTool(
+                'Level 2 warning re. [[Barack Obama]] ([[WP:HG|HG]]) (3.2.0)',
+                'en.wikipedia.org'
+            )
+        );
+    }
+
+    /**
+     * Tests that given edit summary is properly asserted as a revert
+     */
+    public function testIsAutomated()
+    {
+        $this->assertTrue($this->aeh->isAutomated(
+            'Level 2 warning re. [[Barack Obama]] ([[WP:HG|HG]]) (3.2.0)',
+            'en.wikipedia.org'
+        ));
+        $this->assertFalse($this->aeh->isAutomated(
+            'You should try [[WP:Huggle]]',
+            'en.wikipedia.org'
+        ));
+    }
+
+    /**
+     * Test that the revert-related tools of getTools() are properly fetched
+     */
+    public function testRevertTools()
+    {
+        $tools = $this->aeh->getTools('en.wikipedia.org');
+
+        $this->assertArraySubset(
+            ['Huggle' => [
+                'regex' => '\(\[\[WP:HG',
+                'tag' => 'huggle',
+                'link' => 'w:en:Wikipedia:Huggle',
+                'revert' => 'Reverted edits by.*?WP:HG',
+            ]],
+            $tools
+        );
+    }
+
+    /**
+     * Was the edit a revert, based on the edit summary?
+     */
+    public function testIsRevert()
+    {
+        $this->assertTrue($this->aeh->isRevert(
+            'Reverted edits by Mogultalk (talk) ([[WP:HG|HG]]) (3.2.0)',
+            'en.wikipedia.org'
+        ));
+        $this->assertFalse($this->aeh->isRevert(
+            'You should have reverted this edit using [[WP:HG|Huggle]]',
+            'en.wikipedia.org'
+        ));
+    }
+}

--- a/tests/Xtools/EditTest.php
+++ b/tests/Xtools/EditTest.php
@@ -10,21 +10,53 @@ use Xtools\Edit;
 use Xtools\Page;
 use Xtools\Project;
 use Xtools\ProjectRepository;
+use Symfony\Component\DependencyInjection\Container;
+use AppBundle\Helper\AutomatedEditsHelper;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
 /**
  * Tests of the Edit class.
  */
-class EditTest extends \PHPUnit_Framework_TestCase
+class EditTest extends WebTestCase
 {
+    /** @var Container The DI container. */
+    protected $container;
+
+    /** @var Project The project instance. */
+    protected $project;
+
+    /** @var ProjectRepository The project repo instance. */
+    protected $projectRepo;
+
+    /** @var Page The page instance. */
+    protected $page;
+
+    /**
+     * Set up container, class instances and mocks.
+     */
+    public function setUp()
+    {
+        $client = static::createClient();
+        $this->container = $client->getContainer();
+
+        $this->project = new Project('TestProject');
+        $this->projectRepo = $this->getMock(ProjectRepository::class);
+        $this->projectRepo->method('getOne')
+            ->willReturn([
+                'url' => 'https://test.example.org',
+                'dbName' => 'test_wiki',
+                'lang' => 'en',
+            ]);
+        $this->project->setRepository($this->projectRepo);
+        $this->page = new Page($this->project, 'Test_page');
+    }
 
     /**
      * Test the basic functionality of Edit.
      */
     public function testBasic()
     {
-        $project = new Project('TestProject');
-        $page = new Page($project, 'Test_page');
-        $edit = new Edit($page, [
+        $edit = new Edit($this->page, [
             'id' => '1',
             'timestamp' => '20170101100000',
             'minor' => '0',
@@ -33,9 +65,9 @@ class EditTest extends \PHPUnit_Framework_TestCase
             'username' => 'Testuser',
             'comment' => 'Test',
         ]);
-        $this->assertEquals($project, $edit->getProject());
+        $this->assertEquals($this->project, $edit->getProject());
         $this->assertInstanceOf(DateTime::class, $edit->getTimestamp());
-        $this->assertEquals($page, $edit->getPage());
+        $this->assertEquals($this->page, $edit->getPage());
         $this->assertEquals('1483264800', $edit->getTimestamp()->getTimestamp());
         $this->assertEquals(1, $edit->getId());
         $this->assertFalse($edit->isMinor());
@@ -46,18 +78,7 @@ class EditTest extends \PHPUnit_Framework_TestCase
      */
     public function testWikifiedComment()
     {
-        $project = new Project('TestProject');
-        $projectRepo = $this->getMock(ProjectRepository::class);
-        $projectRepo->expects($this->once())
-            ->method('getOne')
-            ->willReturn([
-                'url' => 'https://test.example.org',
-                'dbName' => 'test_wiki',
-                'lang' => 'en',
-            ]);
-        $project->setRepository($projectRepo);
-        $page = new Page($project, 'Test_page');
-        $edit = new Edit($page, [
+        $edit = new Edit($this->page, [
             'id' => '1',
             'timestamp' => '20170101100000',
             'minor' => '0',
@@ -72,5 +93,88 @@ class EditTest extends \PHPUnit_Framework_TestCase
                 "<a target='_blank' href='https://test.example.org/wiki/Test_page'>test page</a>",
             $edit->getWikifiedSummary()
         );
+    }
+
+    /**
+     * Make sure the right tool is detected
+     */
+    public function testTool()
+    {
+        $edit = new Edit($this->page, [
+            'id' => '1',
+            'timestamp' => '20170101100000',
+            'minor' => '0',
+            'length' => '12',
+            'length_change' => '2',
+            'username' => 'Testuser',
+            'comment' => 'Level 2 warning re. [[Barack Obama]] ([[WP:HG|HG]]) (3.2.0)',
+        ]);
+
+        $this->assertArraySubset(
+            [
+                'name' => 'Huggle',
+            ],
+            $edit->getTool($this->container)
+        );
+    }
+
+    /**
+     * Was the edit a revert, based on the edit summary?
+     */
+    public function testIsRevert()
+    {
+        $edit = new Edit($this->page, [
+            'id' => '1',
+            'timestamp' => '20170101100000',
+            'minor' => '0',
+            'length' => '12',
+            'length_change' => '2',
+            'username' => 'Testuser',
+            'comment' => 'You should have reverted this edit using [[WP:HG|Huggle]]',
+        ]);
+
+        $this->assertFalse($edit->isRevert($this->container));
+
+        $edit2 = new Edit($this->page, [
+            'id' => '1',
+            'timestamp' => '20170101100000',
+            'minor' => '0',
+            'length' => '12',
+            'length_change' => '2',
+            'username' => 'Testuser',
+            'comment' => 'Reverted edits by Mogultalk (talk) ([[WP:HG|HG]]) (3.2.0)',
+        ]);
+
+        $this->assertTrue($edit2->isRevert($this->container));
+    }
+
+    /**
+     * Tests that given edit summary is properly asserted as a revert
+     */
+    public function testIsAutomated()
+    {
+        $edit = new Edit($this->page, [
+            'id' => '1',
+            'timestamp' => '20170101100000',
+            'minor' => '0',
+            'length' => '12',
+            'length_change' => '2',
+            'username' => 'Testuser',
+            'comment' => 'You should have reverted this edit using [[WP:HG|Huggle]]',
+        ]);
+
+        $this->assertFalse($edit->isAutomated($this->container));
+
+        $edit2 = new Edit($this->page, [
+            'id' => '1',
+            'timestamp' => '20170101100000',
+            'minor' => '0',
+            'length' => '12',
+            'length_change' => '2',
+            'username' => 'Testuser',
+            'comment' => 'Reverted edits by Mogultalk (talk) ([[WP:HG|HG]]) (3.2.0)',
+        ]);
+
+        $this->assertTrue($edit2->isAutomated($this->container));
     }
 }


### PR DESCRIPTION
Rework shared code for automated edits stuff back to AutomatedEditsHelper

Allow global definitions for automated tools, revert-only regex

Tests