### PR TITLE
EditCounter: Rework month and year counts, horizontal bar chart

### DIFF
--- a/app/Resources/views/editCounter/monthcounts.html.twig
+++ b/app/Resources/views/editCounter/monthcounts.html.twig
@@ -29,55 +29,57 @@
     </div>
 {% else %}
 
-<canvas id="monthcounts-bar-chart"></canvas>
 <script type="text/javascript">
-    new Chart($("#monthcounts-bar-chart"), {
-        type: 'bar',
-        data: {
-            labels: [
-                {%- for year in ec.monthCounts.min_year .. ec.monthCounts.max_year -%}
-                    {%- for month in 1..12 -%}
-                        "{{ year }}/{{ '%02d'|format(month) }}"
-                        {%- if not loop.last %},{% endif %}
-                    {%- endfor -%}
-                    {%- if not loop.last %},{% endif %}
-                {%- endfor -%}
-            ],
-            datasets: [
-                {% for ns_id,dataset in ec.monthCounts.totals %}
-                {
-                    label: "{{ nsName(ns_id, project.namespaces) }}",
-                    backgroundColor: "{{ color(ns_id) }}",
-                    data: [
-                        {% for year in ec.monthCounts.min_year .. ec.monthCounts.max_year %}
-                            {%- for month in 1..12 -%}
-                                {{- attribute(dataset, year~month) -}}
-                                {%- if not loop.last %},{% endif %}
-                            {%- endfor -%}
-                            {%- if not loop.last %},{% endif -%}
-                        {%- endfor -%}
-                    ]
-                }{% if not loop.last %},{% endif %}
+    $(function() {
+        var datasets = [];
+        {% for nsId,namespaceData in ec.monthCounts.totals %}
+            var dataset = {
+                label: "{{ nsName(nsId, project.namespaces) }}",
+                backgroundColor: "{{ color(nsId) }}",
+                data: [],
+            };
+
+            {% for year,yearData in namespaceData %}
+                {% for month,monthData in yearData %}
+                    dataset.data.push({{ monthData }});
                 {% endfor %}
-            ]
-        },
-        options: {
-            scales: {
-                yAxes: [{
-                    stacked: true
-                }],
-                xAxes: [{
-                    stacked: true,
-                    ticks: {
-                        callback: function(value, index, values) {
-                            return (index % 12 == 0) ? value : '';
+            {%- endfor -%}
+
+            datasets.push(dataset);
+        {% endfor %}
+
+        window.chart = new Chart($("#monthcounts-bar-chart"), {
+            type: 'horizontalBar',
+            data: {
+                labels: {{ ec.monthCounts.monthLabels|json_encode|raw }},
+                datasets: datasets
+            },
+            options: {
+                tooltips: {
+                    intersect: true
+                },
+                scales: {
+                    xAxes: [{
+                        stacked: true,
+                        ticks: {
+                            beginAtZero: true,
+                            callback: function(value, index, values) {
+                                if (Math.floor(value) === value) {
+                                    return value;
+                                }
+                            }
                         }
-                    }
-                }]
+                    }],
+                    yAxes: [{
+                        stacked: true
+                    }]
+                }
             }
-        }
+        });
     });
 </script>
+{# 8 * number of months seems to be the magic equation for the height (minimum 28) #}
+<canvas id="monthcounts-bar-chart" height="{{ max(8 * ec.monthCounts.monthLabels|length, 28) }}"></canvas>
 
 {% endif %}
 

--- a/app/Resources/views/editCounter/yearcounts.html.twig
+++ b/app/Resources/views/editCounter/yearcounts.html.twig
@@ -23,40 +23,54 @@
                 <div class="panel-body col-lg-12">
 {% endif %}
 
-<canvas id="yearcounts-canvas"></canvas>
+{# 8 * year count seems to be the magic equation for the height (minimum 28) #}
+<canvas id="yearcounts-canvas" height="{{ max(8 * ec.yearCounts.yearLabels|length, 28) }}"></canvas>
 <script type="text/javascript">
-    new Chart($("#yearcounts-canvas"), {
-        type: 'horizontalBar',
-        data: {
-            labels: [{% for y in ec.yearcounts.years %}"{{ y }}"{% if not loop.last %},{% endif %}{% endfor %}],
-            datasets: [
-                {% for ns_id,yeartotals in ec.yearcounts.totals %}
-                {
-                    label: "{{ nsName(ns_id, project.namespaces) }}",
-                    data: [
-                        {% for y in ec.yearcounts.years %}
-                        {% if attribute(yeartotals, y) is defined %}{{ attribute(yeartotals, y) }}{% else %}0{% endif %}{% if not loop.last %},{% endif %}
-                        {% endfor %}
-                    ],
-                    backgroundColor: "{{ color(ns_id) }}"
-                }{% if not loop.last %},{% endif %}
-                {% endfor %}
-            ]
-        },
-        options: {
-            tooltips: {
-                intersect: true
+    $(function() {
+        var datasets = [];
+        {% for nsId,namespaceData in ec.yearCounts.totals %}
+            var dataset = {
+                label: "{{ nsName(nsId, project.namespaces) }}",
+                backgroundColor: "{{ color(nsId) }}",
+                data: [],
+            };
+
+            {% for year,yearData in namespaceData %}
+                dataset.data.push({{ yearData }});
+            {%- endfor -%}
+
+            datasets.push(dataset);
+        {% endfor %}
+
+        new Chart($("#yearcounts-canvas"), {
+            type: 'horizontalBar',
+            data: {
+                labels: {{ ec.monthCounts.yearLabels|json_encode|raw }},
+                datasets: datasets
             },
-            responsive: true,
-            scales: {
-                xAxes: [{
-                    stacked: true
-                }],
-                yAxes: [{
-                    stacked: true
-                }]
+            options: {
+                tooltips: {
+                    intersect: true
+                },
+                responsive: true,
+                scales: {
+                    xAxes: [{
+                        stacked: true,
+                        ticks: {
+                            beginAtZero: true,
+                            callback: function(value, index, values) {
+                                if (Math.floor(value) === value) {
+                                    return value;
+                                }
+                            }
+                        }
+                    }],
+                    yAxes: [{
+                        stacked: true
+                    }]
+                }
             }
-        }
+        });
     });
 </script>
 

--- a/src/Xtools/EditCounter.php
+++ b/src/Xtools/EditCounter.php
@@ -7,6 +7,8 @@ namespace Xtools;
 
 use DateTime;
 use Exception;
+use DatePeriod;
+use DateInterval;
 
 /**
  * An EditCounter provides statistics about a user's edits on a project.
@@ -31,6 +33,12 @@ class EditCounter extends Model
 
     /** @var int[] The lot totals. */
     protected $logCounts;
+
+    /** @var mixed[] Total numbers of edits per month */
+    protected $monthCounts;
+
+    /** @var mixed[] Total numbers of edits per year */
+    protected $yearCounts;
 
     /** @var int[] Keys are project DB names. */
     protected $globalEditCounts;
@@ -587,70 +595,125 @@ class EditCounter extends Model
     }
 
     /**
-     * Get the total numbers of edits per year.
-     * @return int[]
+     * Get the total numbers of edits per month.
+     * @param null|DateTime [$currentTime] - *USED ONLY FOR UNIT TESTING*
+     *   so we can mock the current DateTime.
+     * @return mixed[] With keys 'yearLabels', 'monthLabels' and 'totals',
+     *   the latter keyed by namespace, year and then month.
      */
-    public function yearCounts()
+    public function monthCounts($currentTime = null)
     {
-        $totals = $this->getRepository()->getYearCounts($this->project, $this->user);
-        $out = [
-            'years' => [],
-            'namespaces' => [],
-            'totals' => [],
-        ];
-        foreach ($totals as $total) {
-            $out['years'][$total['year']] = $total['year'];
-            $out['namespaces'][$total['page_namespace']] = $total['page_namespace'];
-            if (!isset($out['totals'][$total['page_namespace']])) {
-                $out['totals'][$total['page_namespace']] = [];
-            }
-            $out['totals'][$total['page_namespace']][$total['year']] = $total['count'];
+        if (isset($this->monthCounts)) {
+            return $this->monthCounts;
         }
 
-        // Make sure data is sorted by namespace
-        ksort($out['namespaces']);
-        ksort($out['totals']);
+        // Set to current month if we're not unit-testing
+        if (!($currentTime instanceof DateTime)) {
+            $currentTime = new DateTime('last day of this month');
+        }
 
-        return $out;
-    }
-
-    /**
-     * Get the total numbers of edits per month.
-     * @return mixed[] With keys 'years', 'namespaces' and 'totals'.
-     */
-    public function monthCounts()
-    {
         $totals = $this->getRepository()->getMonthCounts($this->project, $this->user);
         $out = [
-            'years' => [],
-            'totals' => [],
+            'yearLabels' => [],  // labels for years
+            'monthLabels' => [], // labels for months
+            'totals' => [], // actual totals, grouped by namespace, year and then month
         ];
-        $out['max_year'] = 0;
-        $out['min_year'] = date('Y');
+
+        // This may be null for really old accounts, which we'll account for!
+        $registrationDate = $this->user->getRegistrationDate($this->project);
+        // If not empty, we know the first month/year to show.
+        if (!empty($registrationDate)) {
+            $minYear = (int) $registrationDate->format('Y');
+            $minMonth = $registrationDate->format('m');
+        } else {
+            $minYear = (int) $currentTime->format('Y');
+
+            // For users without a registration date, we'll just
+            //   use January as the first month.
+            $minMonth = 1;
+        }
+
+        // Loop through the database results and fill in the values
+        //   for the months that we have data for.
         foreach ($totals as $total) {
-            // Collect all applicable years and namespaces.
-            $out['max_year'] = max($out['max_year'], $total['year']);
-            $out['min_year'] = min($out['min_year'], $total['year']);
+            // Figure out the first year they made an edit if we don't have a registration date.
+            if (empty($registrationDate)) {
+                $minYear = (int) min($minYear, $total['year']);
+            }
+
             // Collate the counts by namespace, and then year and month.
             $ns = $total['page_namespace'];
             if (!isset($out['totals'][$ns])) {
                 $out['totals'][$ns] = [];
             }
-            $out['totals'][$ns][$total['year'] . $total['month']] = $total['count'];
+
+            // Start array for this year if not already present.
+            if (!isset($out['totals'][$ns][$total['year']])) {
+                $out['totals'][$ns][$total['year']] = [];
+            }
+
+            $out['totals'][$ns][$total['year']][$total['month']] = (int) $total['count'];
         }
-        // Fill in the blanks (where no edits were made in a given month for a namespace).
-        for ($y = $out['min_year']; $y <= $out['max_year']; $y++) {
-            for ($m = 1; $m <= 12; $m++) {
-                foreach ($out['totals'] as $nsId => &$total) {
-                    if (!isset($total[$y . $m])) {
-                        $total[$y . $m] = 0;
-                    }
+
+        $dateRange = new DatePeriod(
+            new DateTime("$minYear-$minMonth-01"),
+            new DateInterval('P1M'),
+            $currentTime->modify('first day of this month')
+        );
+
+        foreach ($dateRange as $monthObj) {
+            $year = (int) $monthObj->format('Y');
+            $month = (int) $monthObj->format('n');
+
+            // Fill in labels
+            $out['monthLabels'][] = $monthObj->format('Y/m');
+            if (!in_array($year, $out['yearLabels'])) {
+                $out['yearLabels'][] = $year;
+            }
+
+            foreach (array_keys($out['totals']) as $nsId) {
+                if (!isset($out['totals'][$nsId][$year])) {
+                    $out['totals'][$nsId][$year] = [];
+                }
+
+                if (!isset($out['totals'][$nsId][$year][$month])) {
+                    $out['totals'][$nsId][$year][$month] = 0;
                 }
             }
         }
 
-        // Sort by namespace
+        // One more set of loops to sort by year/month
+        foreach (array_keys($out['totals']) as $nsId) {
+            ksort($out['totals'][$nsId]);
+
+            foreach ($out['totals'][$nsId] as &$yearData) {
+                ksort($yearData);
+            }
+        }
+
+        // Finally, sort the namespaces
         ksort($out['totals']);
+
+        $this->monthCounts = $out;
+        return $out;
+    }
+
+    /**
+     * Get the total numbers of edits per year.
+     * @param null|DateTime [$currentTime] - *USED ONLY FOR UNIT TESTING*
+     *   so we can mock the current DateTime.
+     * @return mixed[] With keys 'yearLabels' and 'totals', the latter
+     *   keyed by namespace then year.
+     */
+    public function yearCounts($currentTime = null)
+    {
+        $out = $this->monthCounts($currentTime);
+
+        foreach ($out['totals'] as $nsId => $years) {
+            foreach ($years as $year => $months) {
+                $out['totals'][$nsId][$year] = array_sum(array_values($months));
+            }
+        }
 
         return $out;
     }

--- a/src/Xtools/User.php
+++ b/src/Xtools/User.php
@@ -63,6 +63,21 @@ class User extends Model
     }
 
     /**
+     * Get the user's registration date on the given project.
+     * @param Project $project
+     * @return DateTime|false False if no registration date was found.
+     */
+    public function getRegistrationDate(Project $project)
+    {
+        $registrationDate = $this->getRepository()->getRegistrationDate(
+            $project->getDatabaseName(),
+            $this->getUsername()
+        );
+
+        return DateTime::createFromFormat('YmdHis', $registrationDate);
+    }
+
+    /**
      * Get a list of this user's groups on the given project.
      * @param Project $project The project.
      * @return string[]

--- a/tests/Xtools/UserTest.php
+++ b/tests/Xtools/UserTest.php
@@ -122,6 +122,26 @@ class UserTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * Registration date of the user
+     */
+    public function testRegistrationDate()
+    {
+        $userRepo = $this->getMock(UserRepository::class);
+        $userRepo->expects($this->once())
+            ->method('getRegistrationDate')
+            ->willReturn('20170101000000');
+        $user = new User('TestUser');
+        $user->setRepository($userRepo);
+
+        $projectRepo = $this->getMock(ProjectRepository::class);
+        $project = new Project('wiki.example.org');
+        $project->setRepository($projectRepo);
+
+        $regDateTime = new DateTime('2017-01-01 00:00:00');
+        $this->assertEquals($regDateTime, $user->getRegistrationDate($project));
+    }
+
+    /**
      * User's non-automated edits
      */
     public function testGetNonAutomatedEdits()


### PR DESCRIPTION
Only show months from registration date to present

getRegistrationDate() added to User

This is a precursor to [T171277](https://phabricator.wikimedia.org/T171277). The JS to add the actual totals for each month is a little tricky, so I wanted to first get this preliminary work out as a separate PR.