### PR TITLE
Fix lang-exists check to also be ucfirst

### DIFF
--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -151,7 +151,7 @@ class AppExtension extends Extension
      */
     public function getLangName()
     {
-        return in_array($this->getIntuition()->getLangName(), $this->getAllLangs())
+        return in_array(ucfirst($this->getIntuition()->getLangName()), $this->getAllLangs())
             ? $this->getIntuition()->getLangName()
             : 'English';
     }


### PR DESCRIPTION
The list returned by getAllLangs has ucfirst language names, so
we do the same here when checking for support of the current
language.

Bug: https://phabricator.wikimedia.org/T171815