### PR TITLE
Page: Don't include ns in title when counting links and redirects.

### DIFF
--- a/app/Resources/views/articleInfo/result.html.twig
+++ b/app/Resources/views/articleInfo/result.html.twig
@@ -237,11 +237,12 @@
                         <td>{{ msg('links-external') }}</td>
                         <td>{{ links_ext_count|number_format }}</td>
                     </tr>
-                    <tr>
-                        <td>{{ msg('page-watchers') }}</td>
-                        <td>{{ page.watchers is defined ? page.watchers : '< 30' }}</td>
-                    </tr>
-                    </tr>
+                    {% if page.watchers is not empty %}
+                        <tr>
+                            <td>{{ msg('page-watchers') }}</td>
+                            <td>{{ page.watchers is not empty }}</td>
+                        </tr>
+                    {% endif %}
                     {% if isWMFLabs() %}
                     <tr>
                         <td>{{ msg('pageviews') }} (60 {{ msg('num-days', [60]) }})</td>

--- a/src/Xtools/Page.php
+++ b/src/Xtools/Page.php
@@ -58,6 +58,18 @@ class Page extends Model
     }
 
     /**
+     * Get the page's title without the namespace.
+     * @return string
+     */
+    public function getTitleWithoutNamespace()
+    {
+        $info = $this->getPageInfo();
+        $title = isset($info['title']) ? $info['title'] : $this->unnormalizedPageName;
+        $nsName = $this->getNamespaceName();
+        return str_replace($nsName . ':', '', $title);
+    }
+
+    /**
      * Get this page's database ID.
      * @return int
      */
@@ -109,6 +121,18 @@ class Page extends Model
     {
         $info = $this->getPageInfo();
         return isset($info['ns']) ? $info['ns'] : null;
+    }
+
+    /**
+     * Get the name of the namespace of this page.
+     * @return string
+     */
+    public function getNamespaceName()
+    {
+        $info = $this->getPageInfo();
+        return isset($info['ns'])
+            ? $this->getProject()->getNamespaces()[$info['ns']]
+            : null;
     }
 
     /**

--- a/src/Xtools/PagesRepository.php
+++ b/src/Xtools/PagesRepository.php
@@ -368,7 +368,7 @@ class PagesRepository extends Repository
 
         $params = [
             'id' => $page->getId(),
-            'title' => str_replace(' ', '_', $page->getTitle()),
+            'title' => str_replace(' ', '_', $page->getTitleWithoutNamespace()),
             'namespace' => $page->getNamespace(),
         ];
 

--- a/tests/Xtools/PageTest.php
+++ b/tests/Xtools/PageTest.php
@@ -79,29 +79,38 @@ class PageTest extends KernelTestCase
      */
     public function testBasicGetters()
     {
+        $project = $this->getMock(Project::class, ['getNamespaces'], ['TestProject']);
+        $project->method('getNamespaces')
+            ->willReturn([
+                '',
+                'Talk',
+                'User',
+            ]);
+
         $pageRepo = $this->getMock(PagesRepository::class, ['getPageInfo']);
         $pageRepo->expects($this->once())
             ->method('getPageInfo')
             ->willReturn([
                 'pageid' => '42',
-                'fullurl' => 'https://example.org/Page',
+                'fullurl' => 'https://example.org/User:Test',
                 'watchers' => 5000,
-                'ns' => 0,
+                'ns' => 2,
                 'length' => 300,
                 'pageprops' => [
                     'wikibase_item' => 'Q95',
                 ],
             ]);
-
-        $page = new Page(new Project('TestProject'), 'Test_Page');
+        $page = new Page($project, 'User:Test');
         $page->setRepository($pageRepo);
 
         $this->assertEquals(42, $page->getId());
-        $this->assertEquals('https://example.org/Page', $page->getUrl());
+        $this->assertEquals('https://example.org/User:Test', $page->getUrl());
         $this->assertEquals(5000, $page->getWatchers());
         $this->assertEquals(300, $page->getLength());
-        $this->assertEquals(0, $page->getNamespace());
+        $this->assertEquals(2, $page->getNamespace());
+        $this->assertEquals('User', $page->getNamespaceName());
         $this->assertEquals('Q95', $page->getWikidataId());
+        $this->assertEquals('Test', $page->getTitleWithoutNamespace());
     }
 
     /**


### PR DESCRIPTION
Add helpers for getNamespaceName and getTitleWithoutNamespace

Bug: https://phabricator.wikimedia.org/T173483