### PR TITLE
Don't let display titles be larger than default font size

### DIFF
--- a/app/Resources/views/editCounter/latest_global.html.twig
+++ b/app/Resources/views/editCounter/latest_global.html.twig
@@ -58,7 +58,7 @@
                 &middot;
                 <a href="{{ path('TopEditsResults', {project:edit.project.databaseName, username:user.username, namespace:edit.page.namespace, article:edit.page.title}) }}">{{ msg('tool-topedits') }}</a>
             </td>
-            <td class="sort-entry--page-title" data-value="{{ edit.page.title }}">
+            <td class="sort-entry--page-title display-title" data-value="{{ edit.page.title }}">
                 {{ wiki.pageLink(edit.page, edit.page.displayTitle) }}
             </td>
             <td class="sort-entry--size" data-value="{{ edit.lengthChange }}">

--- a/app/Resources/views/topedits/result_article.html.twig
+++ b/app/Resources/views/topedits/result_article.html.twig
@@ -12,7 +12,7 @@
             </a>
             {{ wiki.userLink(user, project) }}
             &bull;
-            {{ wiki.pageLink(page, page.displayTitle|raw) }}
+            {{ wiki.pageLink(page, page.title) }}
             <small>
                 &bull;
                 {{ project.title }}
@@ -27,7 +27,9 @@
                 <tr>
                     <td>{{ msg('article') }}</td>
                     <td>
-                        {{ wiki.pageLink(page, page.displaytitle|raw) }}
+                        <span class="display-title">
+                            {{ wiki.pageLink(page, page.displaytitle|raw) }}
+                        </span>
                         <small>({{ wiki.pageLogLink(page) }}
                         &middot; <a href="{{ path('ArticleInfoResult', {project:project.domain, article:page.title}) }}">{{ msg('tool-articleinfo') }}</a>)</small>
                     </td>

--- a/app/Resources/views/topedits/result_namespace.html.twig
+++ b/app/Resources/views/topedits/result_namespace.html.twig
@@ -60,7 +60,7 @@
                     <td class="sort-entry--edits tdnum" data-value="{{ edit.count }}">
                         {{ edit.count|number_format }}
                     </td>
-                    <td class="sort-entry--page" data-value="{{ edit.page_title_ns }}">
+                    <td class="sort-entry--page display-title" data-value="{{ edit.page_title_ns }}">
                         {{ wiki.pageLinkRaw(edit.page_title_ns, project, edit.displaytitle) }}
                     </td>
                     <td>

--- a/web/static/css/application.scss
+++ b/web/static/css/application.scss
@@ -605,6 +605,11 @@ section > .panel-body {
     }
 }
 
+// Don't let fonts in display titles get too big
+.display-title * {
+    font-size: inherit !important;
+}
+
 .error-wrapper {
     font-size: 18px;
 


### PR DESCRIPTION
Don't use displaytitle in heading of page

Bug: https://phabricator.wikimedia.org/T173497