### PR TITLE
Check for 'www.' prefix on project names

### DIFF
--- a/src/Xtools/ProjectRepository.php
+++ b/src/Xtools/ProjectRepository.php
@@ -129,7 +129,7 @@ class ProjectRepository extends Repository
      *   to make database queries. More comprehensive metadata can be fetched
      *   with getMetadata() at the expense of an API call.
      * @param string $project A project URL, domain name, or database name.
-     * @return string[] With 'dbName', 'url' and 'lang' keys.
+     * @return string[]|bool With 'dbName', 'url' and 'lang' keys; or false if not found.
      */
     public function getOne($project)
     {
@@ -145,7 +145,9 @@ class ProjectRepository extends Repository
             foreach ($this->cache->getItem($this->cacheKeyAllProjects)->get() as $projMetadata) {
                 if ($projMetadata['dbName'] == "$project"
                     || $projMetadata['url'] == "$project"
-                    || $projMetadata['url'] == "https://$project") {
+                    || $projMetadata['url'] == "https://$project"
+                    || $projMetadata['url'] == "https://$project.org"
+                    || $projMetadata['url'] == "https://www.$project") {
                     $this->log->debug(__METHOD__ . " Using cached data for $project");
                     return $projMetadata;
                 }
@@ -165,11 +167,14 @@ class ProjectRepository extends Repository
             // so we need to query for it accordingly, trying different variations the user
             // might have inputted.
             ->orwhere($wikiQuery->expr()->like('url', ':projectUrl'))
-            ->orwhere($wikiQuery->expr()
-                ->like('url', ':projectUrl2'))
+            ->orwhere($wikiQuery->expr()->like('url', ':projectUrl2'))
+            ->orwhere($wikiQuery->expr()->like('url', ':projectUrl3'))
+            ->orwhere($wikiQuery->expr()->like('url', ':projectUrl4'))
             ->setParameter('project', $project)
             ->setParameter('projectUrl', "https://$project")
-            ->setParameter('projectUrl2', "https://$project.org");
+            ->setParameter('projectUrl2', "https://$project.org")
+            ->setParameter('projectUrl3', "https://www.$project")
+            ->setParameter('projectUrl4', "https://www.$project.org");
         $wikiStatement = $wikiQuery->execute();
 
         // Fetch and cache the wiki data.

--- a/web/static/css/application.scss
+++ b/web/static/css/application.scss
@@ -415,6 +415,10 @@ section > .panel-body {
     opacity: 0.8;
 }
 
+input.form-control.show-loader {
+    background: url("../images/loader.gif") no-repeat right center;
+}
+
 .stat-list {
     margin-bottom: 20px;
 

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -346,13 +346,20 @@
             $('#project_input').on('change', function () {
                 var newProject = this.value;
 
+                // Show the spinner.
+                $(this).addClass('show-loader');
+
                 /** global: xtBaseUrl */
                 $.get(xtBaseUrl + 'api/normalizeProject/' + newProject).done(function (data) {
                     // Keep track of project API path for use in page title autocompletion
                     apiPath = data.api;
                     lastProject = newProject;
                     setupAutocompletion();
-                }).fail(revertToValidProject.bind(this, newProject));
+                }).fail(
+                    revertToValidProject.bind(this, newProject)
+                ).always(function () {
+                    $('#project_input').removeClass('show-loader');
+                });
             });
         }
     }
@@ -369,10 +376,7 @@
         $('#project_input').on('change', function () {
             // Disable the namespace selector and show a spinner while the data loads.
             $('#namespace_select').prop('disabled', true);
-
-            var $loader = $('span.loader');
-            $('label[for="namespace_select"]').append($loader);
-            $loader.removeClass('hidden');
+            $(this).addClass('show-loader');
 
             var newProject = this.value;
 
@@ -405,7 +409,7 @@
                 setupAutocompletion();
             }).fail(revertToValidProject.bind(this, newProject)).always(function () {
                 $('#namespace_select').prop('disabled', false);
-                $loader.addClass('hidden');
+                $('#project_input').removeClass('show-loader');
             });
         });
 
@@ -469,6 +473,7 @@
             timeout: 200,
             triggerLength: 1,
             method: 'get',
+            loadingClass: 'show-loader',
             preDispatch: null,
             preProcess: null,
         };


### PR DESCRIPTION
We were already checking for ".org" suffixes, so this just adds
a "www." prefix as well (and checks for them both as well as
singularly).

Also adds the loading spinner to the Project form field label, to
match what's done for the Namespace form field.

Bug: https://phabricator.wikimedia.org/T170763