### PR TITLE
AdminStats: fix sorting of some columns, make heading sticky

### DIFF
--- a/app/Resources/views/adminStats/result.html.twig
+++ b/app/Resources/views/adminStats/result.html.twig
@@ -52,7 +52,7 @@
         <div style="clear:both"></div>
 
         {% set content %}
-            <table class="table table-bordered table-hover table-striped top-editors-table">
+            <table class="table table-bordered table-hover table-striped top-editors-table table-sticky-header">
                 <thead><tr>
                     <th>#</th>
                     {% for key in ['username', 'user-groups', 'links', 'total', 'delete', 'restore', 're-block', 'unblock', 're-protect', 'unprotect', 'import', 'rights'] %}
@@ -72,7 +72,7 @@
                             <td class="sort-entry--username" data-value="{{ username }}">
                                 {{ wiki.userLink(username, project) }}
                             </td>
-                            <td class="sort-entry--groups" data-value="{{ value.groups }}">{{ value.groups }}</td>
+                            <td class="sort-entry--user-groups" data-value="{{ value.groups }}">{{ value.groups }}</td>
                             <td>
                                 {% if enabled('ec') %}
                                     <a title="{{ msg('tool-ec') }}" href="{{ path('EditCounterResult', {project: project.domain, username: username}) }}" >ec</a>
@@ -86,9 +86,9 @@
                             <td class="sort-entry--total" data-value="{{ value.mtotal }}">{{ value.mtotal|number_format }}</td>
                             <td class="sort-entry--delete" data-value="{{ value.mdelete }}">{{ value.mdelete|number_format }}</td>
                             <td class="sort-entry--restore" data-value="{{ value.mrestore }}">{{ value.mrestore|number_format }}</td>
-                            <td class="sort-entry--re_block" data-value="{{ value.mblock }}">{{ value.mblock|number_format }}</td>
-                            <td class="sort-entry--groups" data-value="{{ value.munblock }}">{{ value.munblock|number_format }}</td>
-                            <td class="sort-entry--re_protect" data-value="{{ value.mprotect }}">{{ value.mprotect|number_format }}</td>
+                            <td class="sort-entry--re-block" data-value="{{ value.mblock }}">{{ value.mblock|number_format }}</td>
+                            <td class="sort-entry--unblock" data-value="{{ value.munblock }}">{{ value.munblock|number_format }}</td>
+                            <td class="sort-entry--re-protect" data-value="{{ value.mprotect }}">{{ value.mprotect|number_format }}</td>
                             <td class="sort-entry--unprotect" data-value="{{ value.munprotect }}">{{ value.munprotect|number_format }}</td>
                             <td class="sort-entry--import" data-value="{{ value.mimport }}">{{ value.mimport|number_format }}</td>
                             <td class="sort-entry--rights" data-value="{{ value.mrights }}">{{ value.mrights|number_format }}</td>

--- a/web/static/css/application.scss
+++ b/web/static/css/application.scss
@@ -242,6 +242,16 @@ $tooltip-shadow: #ccc;
         white-space: nowrap;
     }
 }
+.table-sticky-header {
+    position: relative;
+
+    .sticky-heading {
+        background: white;
+        left: 0;
+        position: absolute;
+        top: 0;
+    }
+}
 .xt-alert {
     padding: 5px;
     margin: 5px;


### PR DESCRIPTION
Works well, but there's a trade off of making the sticky header:
* `position:fixed` - buttery smooth when scrolling up and down, but it ends up on top of all other content, despite z-indexing, and you need to add listeners to make it position correctly when scrolling left/right
* `position:absolute` - buttery smooth when scrolling left and right, and it correctly is embedded within the table and not on top of all content. However it looks jumpy on mobile or possibly desktop devices with slow JavaScript engines

I went with `position:absolute`, but we can try the other again if you think it's too ugly :)