### PR TITLE
Better API design, add automated editcounter endpoint

### DIFF
--- a/app/Resources/views/articleInfo/articleinfo.js.twig
+++ b/app/Resources/views/articleInfo/articleinfo.js.twig
@@ -27,7 +27,7 @@ $(function () {
 
     $.get(
         '{{ app.request.getSchemeAndHttpHost()|raw }}' +
-        '/api/articleinfo/' +
+        '/api/page/articleinfo/' +
         mw.config.get('wgServerName') + '/' +
         mw.config.get('wgPageName') + '?format=html' +
         '&uselang=' + mw.config.get('wgUserLanguage')

--- a/docs/api/page.rst
+++ b/docs/api/page.rst
@@ -8,7 +8,7 @@ API endpoints related to a single page.
 
 Article info
 ============
-``GET /api/articleinfo/{project}/{article}/{format}``
+``GET /api/page/articleinfo/{project}/{article}/{format}``
 
 Get basic information about the history of a page.
 
@@ -21,4 +21,4 @@ Get basic information about the history of a page.
 
 Get basic information about `Albert Einstein <https://en.wikipedia.org/wiki/Albert_Einstein>`_.
 
-    https://xtools.wmflabs.org/api/articleinfo/en.wikipedia.org/Albert_Einstein
+    https://xtools.wmflabs.org/api/page/articleinfo/en.wikipedia.org/Albert_Einstein

--- a/docs/api/project.rst
+++ b/docs/api/project.rst
@@ -6,7 +6,7 @@ API endpoints related to a project.
 
 Normalize project
 =================
-``GET /api/normalize_project/{project}``
+``GET /api/project/normalize/{project}``
 
 Get the URL, database name, domain and API path of a given project.
 
@@ -18,13 +18,13 @@ Get the URL, database name, domain and API path of a given project.
 
 Basic access information about the English Wikipedia.
 
-    https://xtools.wmflabs.org/api/normalize_project/enwiki
-    https://xtools.wmflabs.org/api/normalize_project/en.wikipedia
-    https://xtools.wmflabs.org/api/normalize_project/en.wikipedia.org
+    https://xtools.wmflabs.org/api/project/normalize/enwiki
+    https://xtools.wmflabs.org/api/project/normalize/en.wikipedia
+    https://xtools.wmflabs.org/api/project/normalize/en.wikipedia.org
 
 Namespaces
 ==========
-``GET /api/namespaces/{project}``
+``GET /api/project/namespaces/{project}``
 
 Get the localized names for each namespace of the given project.
 The API endpoint for the project is also returned.
@@ -37,6 +37,6 @@ The API endpoint for the project is also returned.
 
 Get the namespace IDs and names of the German Wikipedia.
 
-    https://xtools.wmflabs.org/api/namespaces/dewiki
-    https://xtools.wmflabs.org/api/namespaces/de.wikipedia
-    https://xtools.wmflabs.org/api/namespaces/de.wikipedia.org
+    https://xtools.wmflabs.org/api/project/namespaces/dewiki
+    https://xtools.wmflabs.org/api/project/namespaces/de.wikipedia
+    https://xtools.wmflabs.org/api/project/namespaces/de.wikipedia.org

--- a/docs/api/user.rst
+++ b/docs/api/user.rst
@@ -6,9 +6,35 @@ User API
 
 API endpoints related to a user.
 
+Automated edit counter
+======================
+``GET /api/user/automated_editcount/{project}/{username}/{namespace}/{start}/{end}/{offset}/{tools}``
+
+Get the number of (semi-)automated edits made by the given user in the given namespace and date range.
+You can optionally pass in ``?tools=1`` to get individual counts of each (semi-)automated tool that was used.
+
+**Parameters:**
+
+* ``project`` (**required**) - Project domain or database name.
+* ``username`` (**required**) - Account's username.
+* ``namespace`` (**required**) - Namespace ID or 'all' for all namespaces.
+* ``start`` - Start date in the format ``YYYY-MM-DD``. Leave this and ``end`` blank to retrieve the most recent data.
+* ``end`` - End date in the format ``YYYY-MM-DD``. Leave this and ``start`` blank to retrieve the most recent data.
+* ``tools`` - Set to any non-blank value to include the tools that were used and thier counts.
+
+**Example:**
+
+Get the number of (semi-)automated edits made by `Jimbo Wales <https://en.wikipedia.org/wiki/User:Jimbo_Wales>`_ on the English Wikipedia.
+
+    https://xtools.wmflabs.org/api/user/automated_editcount/en.wikipedia/Jimbo_Wales
+
+Get a list of the known (semi-)automated tools used by `Jimbo Wales <https://en.wikipedia.org/wiki/User:Jimbo_Wales>`_ in the mainspace on the English Wikipedia, and how many times they were used.
+
+    https://xtools.wmflabs.org/api/user/automated_editcount/en.wikipedia/Jimbo_Wales/0///1
+
 Non-automated edits
 ===================
-``GET /api/nonautomated_edits/{project}/{username}/{namespace}/{start}/{end}/{offset}``
+``GET /api/user/nonautomated_edits/{project}/{username}/{namespace}/{start}/{end}/{offset}``
 
 Get non-automated contributions for the given user, namespace and date range.
 
@@ -25,4 +51,4 @@ Get non-automated contributions for the given user, namespace and date range.
 
 Get the newest non-automated mainspace contributions made by `Jimbo Wales <https://en.wikipedia.org/wiki/User:Jimbo_Wales>`_ on the English Wikipedia.
 
-    https://xtools.wmflabs.org/api/nonautomated_edits/en.wikipedia/Jimbo_Wales/0
+    https://xtools.wmflabs.org/api/user/nonautomated_edits/en.wikipedia/Jimbo_Wales/0

--- a/src/Xtools/User.php
+++ b/src/Xtools/User.php
@@ -170,9 +170,9 @@ class User extends Model
     /**
      * Get edit count within given timeframe and namespace
      * @param Project $project
-     * @param int|string [$namespace] Namespace ID or 'all' for all namespaces
-     * @param string [$start] Start date in a format accepted by strtotime()
-     * @param string [$end] End date in a format accepted by strtotime()
+     * @param int|string $namespace Namespace ID or 'all' for all namespaces
+     * @param string $start Start date in a format accepted by strtotime()
+     * @param string $end End date in a format accepted by strtotime()
      */
     public function countEdits(Project $project, $namespace = 'all', $start = '', $end = '')
     {
@@ -182,9 +182,9 @@ class User extends Model
     /**
      * Get the number of edits this user made using semi-automated tools.
      * @param Project $project
-     * @param string|int [$namespace] Namespace ID or 'all'
-     * @param string [$start] Start date in a format accepted by strtotime()
-     * @param string [$end] End date in a format accepted by strtotime()
+     * @param string|int $namespace Namespace ID or 'all'
+     * @param string $start Start date in a format accepted by strtotime()
+     * @param string $end End date in a format accepted by strtotime()
      * @return int Result of query, see below.
      */
     public function countAutomatedEdits(Project $project, $namespace = 'all', $start = '', $end = '')
@@ -195,10 +195,10 @@ class User extends Model
     /**
      * Get non-automated contributions for this user.
      * @param Project $project
-     * @param string|int [$namespace] Namespace ID or 'all'
-     * @param string [$start] Start date in a format accepted by strtotime()
-     * @param string [$end] End date in a format accepted by strtotime()
-     * @param int [$offset] Used for pagination, offset results by N edits
+     * @param string|int $namespace Namespace ID or 'all'
+     * @param string $start Start date in a format accepted by strtotime()
+     * @param string $end End date in a format accepted by strtotime()
+     * @param int $offset Used for pagination, offset results by N edits
      * @return array[] Result of query, with columns (string) 'page_title',
      *   (int) 'page_namespace', (int) 'rev_id', (DateTime) 'timestamp',
      *   (bool) 'minor', (int) 'length', (int) 'length_change', (string) 'comment'
@@ -242,11 +242,11 @@ class User extends Model
     }
 
     /**
-     * Get non-automated contributions for the given user.
+     * Get counts of known automated tools used by the given user.
      * @param Project $project
-     * @param string|int [$namespace] Namespace ID or 'all'
-     * @param string [$start] Start date in a format accepted by strtotime()
-     * @param string [$end] End date in a format accepted by strtotime()
+     * @param string|int $namespace Namespace ID or 'all'
+     * @param string $start Start date in a format accepted by strtotime()
+     * @param string $end End date in a format accepted by strtotime()
      * @return string[] Each tool that they used along with the count and link:
      *                  [
      *                      'Twinkle' => [

--- a/tests/AppBundle/Controller/ApiControllerTest.php
+++ b/tests/AppBundle/Controller/ApiControllerTest.php
@@ -47,12 +47,12 @@ class ApiControllerTest extends WebTestCase
             ];
 
             // from database name
-            $crawler = $this->client->request('GET', '/api/normalize_project/enwiki');
+            $crawler = $this->client->request('GET', '/api/project/normalize/enwiki');
             $output = json_decode($this->client->getResponse()->getContent(), true);
             $this->assertEquals($expectedOutput, $output);
 
             // from domain name (without .org)
-            $crawler = $this->client->request('GET', '/api/normalize_project/en.wikipedia');
+            $crawler = $this->client->request('GET', '/api/project/normalize/en.wikipedia');
             $output = json_decode($this->client->getResponse()->getContent(), true);
             $this->assertEquals($expectedOutput, $output);
         }
@@ -64,7 +64,7 @@ class ApiControllerTest extends WebTestCase
     public function testNamespaces()
     {
         // Test 404 (for single-wiki setups, that wiki's namespaces are always returned).
-        $crawler = $this->client->request('GET', '/api/namespaces/wiki.that.doesnt.exist.org');
+        $crawler = $this->client->request('GET', '/api/project/namespaces/wiki.that.doesnt.exist.org');
         if ($this->isSingle) {
             $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
         } else {
@@ -72,7 +72,7 @@ class ApiControllerTest extends WebTestCase
         }
 
         if (!$this->isSingle && $this->container->getParameter('app.is_labs')) {
-            $crawler = $this->client->request('GET', '/api/namespaces/fr.wikipedia.org');
+            $crawler = $this->client->request('GET', '/api/project/namespaces/fr.wikipedia.org');
             $this->assertEquals(200, $this->client->getResponse()->getStatusCode());
 
             // Check that a correct namespace value was returned
@@ -80,6 +80,32 @@ class ApiControllerTest extends WebTestCase
             $namespaces = (array) $response['namespaces'];
             $this->assertEquals('Utilisateur', array_values($namespaces)[2]); // User in French
         }
+    }
+
+    /**
+     * Test automated edit counter endpoint.
+     */
+    public function testAutomatedEditCount()
+    {
+        if ($this->isSingle || !$this->container->getParameter('app.is_labs')) {
+            // untestable :(
+            return;
+        }
+
+        $url = '/api/user/automated_editcount/en.wikipedia/musikPuppet/all///1';
+        $crawler = $this->client->request('GET', $url);
+        $response = $this->client->getResponse();
+        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals($response->headers->get('content-type'), 'application/json');
+
+        $data = json_decode($response->getContent(), true);
+        $toolNames = array_keys($data['automated_tools']);
+
+        $this->assertEquals($data['project'], 'en.wikipedia.org');
+        $this->assertEquals($data['username'], 'MusikPuppet');
+        $this->assertGreaterThan(10, $data['automated_editcount']);
+        $this->assertContains('Twinkle', $toolNames);
+        $this->assertContains('Huggle', $toolNames);
     }
 
     /**
@@ -92,16 +118,14 @@ class ApiControllerTest extends WebTestCase
             return;
         }
 
-        $url = '/api/nonautomated_edits/en.wikipedia/ThisIsaTest/all///0';
-
-        // Test 404 (for single-wiki setups, that wiki's namespaces are always returned).
+        $url = '/api/user/nonautomated_edits/en.wikipedia/ThisIsaTest/all///0';
         $crawler = $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals($response->headers->get('content-type'), 'application/json');
 
         // This test account *should* never edit again and be safe for testing...
-        $this->assertCount(1, json_decode($response->getContent(), true)['data']);
+        $this->assertCount(1, json_decode($response->getContent(), true)['nonautomated_edits']);
 
         // Test again for HTML
         $crawler = $this->client->request('GET', $url . '?format=html');
@@ -116,14 +140,16 @@ class ApiControllerTest extends WebTestCase
     public function testArticleInfo()
     {
         if (!$this->isSingle && $this->container->getParameter('app.is_labs')) {
-            $crawler = $this->client->request('GET', '/api/articleinfo/en.wikipedia.org/Main_Page');
+            $crawler = $this->client->request('GET', '/api/page/articleinfo/en.wikipedia.org/Main_Page');
 
             $response = $this->client->getResponse();
             $this->assertEquals(200, $response->getStatusCode());
 
-            $data = json_decode($response->getContent(), true)['data'];
+            $data = json_decode($response->getContent(), true);
 
             // Some basic tests that should always hold true
+            $this->assertEquals($data['project'], 'en.wikipedia.org');
+            $this->assertEquals($data['page'], 'Main Page');
             $this->assertTrue($data['revisions'] > 4000);
             $this->assertTrue($data['editors'] > 400);
             $this->assertEquals($data['author'], 'TwoOneTwo');
@@ -132,9 +158,9 @@ class ApiControllerTest extends WebTestCase
 
             $this->assertEquals(
                 [
-                    'revisions', 'editors', 'author', 'author_editcount', 'created_at',
-                    'created_rev_id', 'modified_at', 'secs_since_last_edit', 'last_edit_id',
-                    'watchers', 'pageviews', 'pageviews_offset',
+                    'project', 'page', 'revisions', 'editors', 'author', 'author_editcount',
+                    'created_at', 'created_rev_id', 'modified_at', 'secs_since_last_edit',
+                    'last_edit_id', 'watchers', 'pageviews', 'pageviews_offset',
                 ],
                 array_keys($data)
             );

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -411,7 +411,7 @@
                 $(this).addClass('show-loader');
 
                 /** global: xtBaseUrl */
-                $.get(xtBaseUrl + 'api/normalizeProject/' + newProject).done(function (data) {
+                $.get(xtBaseUrl + 'api/project/normalize_project/' + newProject).done(function (data) {
                     // Keep track of project API path for use in page title autocompletion
                     apiPath = data.api;
                     lastProject = newProject;
@@ -442,7 +442,7 @@
             var newProject = this.value;
 
             /** global: xtBaseUrl */
-            $.get(xtBaseUrl + 'api/namespaces/' + newProject).done(function (data) {
+            $.get(xtBaseUrl + 'api/project/namespaces/' + newProject).done(function (data) {
                 // Clone the 'all' option (even if there isn't one),
                 // and replace the current option list with this.
                 var $allOption = $('#namespace_select option[value="all"]').eq(0).clone();

--- a/web/static/js/autoedits.js
+++ b/web/static/js/autoedits.js
@@ -38,7 +38,7 @@ $(function () {
 
         /** global: xtBaseUrl */
         $.ajax({
-            url: xtBaseUrl + 'api/nonautomated_edits/' + project + '/' + username + '/' +
+            url: xtBaseUrl + 'api/user/nonautomated_edits/' + project + '/' + username + '/' +
                 namespace + '/' + start + '/' + end + '/' + editOffset + '?format=html',
             timeout: 30000
         }).done(function (data) {


### PR DESCRIPTION
The automated editcount endpoint will be used in the EditCounter performance improvements. As I was adding it I realized our API structure was messy and decided to make it more organized and predictable.