### PR TITLE
Add option to make async queries for Edit Counter.

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -21,6 +21,7 @@ class AppKernel extends Kernel
             new Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new Snc\RedisBundle\SncRedisBundle(),
             new FOS\RestBundle\FOSRestBundle(),
+            new EightPoints\Bundle\GuzzleBundle\GuzzleBundle(),
             new JMS\SerializerBundle\JMSSerializerBundle(),
             new Nelmio\CorsBundle\NelmioCorsBundle(),
             new AppBundle\AppBundle(),

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -9,6 +9,9 @@
     <script type="text/javascript">
         xtBaseUrl = "{{ path('homepage') }}";
 
+        {# For the JavaScript variable, we don't want to include the protocol, just to safeguard against x-origin policy violation #}
+        xtApiUrl = "{{ apiUrl is defined ? apiUrl : path('homepage') }}".replace(/^https?:\/\//, '//');
+
         {# For $.i18n, loaded in application.js #}
         i18nLang = "{{ lang() }}";
         i18nPath = "{{ asset('static/i18n/' ~ lang() ~ '.json') }}";
@@ -37,7 +40,6 @@
             'static/css/articleinfo.scss'
             'static/css/autoedits.scss'
             'static/css/editcounter.scss'
-            'static/css/index.scss'
             'static/css/pages.scss'
             output='static/production/application.css' %}
         <link rel="stylesheet" href="{{ asset_url }}" />

--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -374,6 +374,8 @@
         </tbody>
     </table>
 </div>
+
+{# ======================== GLOBAL EDITS ======================== #}
 <div class="col-lg-4 stat-list clearfix">
     <table class="table top-project-edit-counts">
         <tbody class="stat-list--group">

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -65,6 +65,7 @@ twig:
         noticeDisplay: '%app.noticeDisplay%'
         noticeStyle:   '%app.noticeStyle%'
         noticeText:    '%app.noticeText%'
+        apiUrl:        '%app.multithread.api_url%'
 
 
 # Doctrine Configuration
@@ -171,6 +172,16 @@ fos_rest:
         mime_types:
             json: ['application/json']
             html: ['text/html']
+
+guzzle:
+    logging: true
+
+    clients:
+        xtools:
+            options:
+                headers:
+                    Accept: "application/json"
+                timeout: 30
 
 monolog:
     channels: ['rate_limit']

--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -56,6 +56,9 @@ parameters:
     app.rate_limit_time: 5
     app.rate_limit_count: 10
 
+    app.multithread.enable: 0
+    app.multithread.api_url: https://xtools.example.org/
+
     # Enabling or disabling of individual tools
     enable.adminscore: 1
     enable.adminstats: 1

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "jms/serializer-bundle": "^1.4",
         "symfony/stopwatch": "^3.2",
         "doctrine/doctrine-migrations-bundle": "^1.0",
-        "doctrine/migrations": "1.2.*"
+        "doctrine/migrations": "1.2.*",
+        "eightpoints/guzzle-bundle": "^6.1"
     },
     "require-dev": {
         "sensio/generator-bundle": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "180627c11977a4a39f0048820ba2add3",
+    "content-hash": "1074e4dc48d4262dead6da4f9dce2f7d",
     "packages": [
         {
             "name": "addwiki/mediawiki-api",
@@ -1099,6 +1099,125 @@
                 "orm"
             ],
             "time": "2016-12-18T15:42:34+00:00"
+        },
+        {
+            "name": "eightpoints/guzzle-bundle",
+            "version": "v6.1.0",
+            "target-dir": "EightPoints/Bundle/GuzzleBundle",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/8p/GuzzleBundle.git",
+                "reference": "35a44f7cfa472643375b53151d82c40f4a53e8fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/8p/GuzzleBundle/zipball/35a44f7cfa472643375b53151d82c40f4a53e8fe",
+                "reference": "35a44f7cfa472643375b53151d82c40f4a53e8fe",
+                "shasum": ""
+            },
+            "require": {
+                "eightpoints/guzzle-wsse-middleware": "~4.0",
+                "guzzlehttp/guzzle": "~6.0",
+                "php": ">=5.6",
+                "psr/log": "~1.0",
+                "symfony/dependency-injection": "~2.3|~3.0",
+                "symfony/event-dispatcher": "~2.3|~3.0",
+                "symfony/expression-language": "~2.3|~3.0",
+                "symfony/http-kernel": "~2.3|~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5.4",
+                "symfony/config": "2.3|~3.0"
+            },
+            "type": "symfony-bundle",
+            "autoload": {
+                "psr-0": {
+                    "EightPoints\\Bundle\\GuzzleBundle": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Community",
+                    "homepage": "https://github.com/8p/GuzzleBundle/contributors"
+                },
+                {
+                    "name": "Florian Preusner",
+                    "email": "florian.preusner@8points.de",
+                    "homepage": "https://github.com/florianpreusner"
+                }
+            ],
+            "description": "Integrates Guzzle into Symfony2, comes with WSSE Plugin for RESTful Interfaces",
+            "homepage": "https://github.com/8p/GuzzleBundle",
+            "keywords": [
+                "Guzzle",
+                "bundle",
+                "client",
+                "curl",
+                "http client",
+                "rest",
+                "symfony",
+                "web service"
+            ],
+            "time": "2017-09-13T12:42:59+00:00"
+        },
+        {
+            "name": "eightpoints/guzzle-wsse-middleware",
+            "version": "v4.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/8p/guzzle-wsse-middleware.git",
+                "reference": "3998dae6fed29f2d3384024764046b63a764ddda"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/8p/guzzle-wsse-middleware/zipball/3998dae6fed29f2d3384024764046b63a764ddda",
+                "reference": "3998dae6fed29f2d3384024764046b63a764ddda",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": ">=6.0",
+                "php": ">=5.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "EightPoints\\Guzzle": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Florian Preusner",
+                    "email": "florian.preusner@8points.de",
+                    "homepage": "https://github.com/florianpreusner"
+                },
+                {
+                    "name": "Community",
+                    "homepage": "https://github.com/eightpoints/guzzle-wsse-middleware/contributors"
+                }
+            ],
+            "description": "WSSE Middleware for Guzzle, a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "https://github.com/8p/guzzle-wsse-middleware",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "middleware",
+                "plugin",
+                "rest",
+                "web service",
+                "wsse"
+            ],
+            "time": "2016-06-03T14:03:33+00:00"
         },
         {
             "name": "fig/link-util",

--- a/docs/administration.rst
+++ b/docs/administration.rst
@@ -18,6 +18,16 @@ Using the above example, if you try to load the same page more than 5 times with
 
 Any requests that are denied are logged at ``var/logs/rate_limit.log``.
 
+You can blacklist user agents and URIs using the request_blacklist.yml file.
+
+.. _offload_api:
+
+Offloading API requests
+=======================
+XTools features a rich public API. If you expect your XTools installation will receive a lot of traffic, you can send your API consumers (which may include bots, for instance) to a dedicated server so that resources on the main app server are not hogged.
+
+@TODO document how to forward API requests to another server via Apache config.
+
 Killing slow queries
 ====================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -64,6 +64,8 @@ Application
 - **app.is_labs** - Whether XTools lives on the Wikimedia Foundation Labs environment.  This should be set to false.
 - **app.rate_limit_time** - Number of minutes during which ``app.rate_limit_count`` requests from the same user are allowed. Set this to ``0`` to disable rate limiting.
 - **app.rate_limit_count** - Number of requests from the same user that are allowed during the time frame specified by ``app.rate_limit_time``. Set this to ``0`` to disable rate limiting.
+- **app.multithread.enable** Set to 1 to speed up the Edit Counter and other tools by making multiple asynchronous queries. This requires a multithreaded server (such as Apache), so you should set this to 0 if you are using the default Symfony server in your development environment.
+- **app.multithread.api_url** - If multithreading is enabled, expensive requests to the internal XTools API will go to this URL. This should almost always be the base domain of your app server (including trailing slash, example https://xtools.wmflabs.org/). However you could use this to offload requests to another server with an identical installation of XTools. The better approach is probably to keep this parameter set to your main app server, and configure your server to forward requests to ``/api`` to the API server. See the :ref:`administration <offload_api>` section for more.
 - **wiki_url** - URL to use if app.single_wiki is enabled.  The title of pages is attached to the end.
 - **api_path** - The API path for the project, usually /w/api.php
 - **opted_in** - A list of database names of projects that will display :ref:`restricted statistics <optin>` regardless of individual users' preferences

--- a/src/Xtools/EditCounterRepository.php
+++ b/src/Xtools/EditCounterRepository.php
@@ -260,13 +260,14 @@ class EditCounterRepository extends Repository
      */
     protected function globalEditCountsFromCentralAuth(User $user, Project $project)
     {
-        $this->log->debug(__METHOD__." Getting global edit counts for ".$user->getUsername());
         // Set up cache and stopwatch.
         $cacheKey = 'globalRevisionCounts.'.$user->getCacheKey();
         if ($this->cache->hasItem($cacheKey)) {
             return $this->cache->getItem($cacheKey)->get();
         }
         $this->stopwatch->start($cacheKey, 'XTools');
+
+        $this->log->debug(__METHOD__." Getting global edit counts from for ".$user->getUsername());
 
         // Load all projects, so it doesn't have to request metadata about each one as it goes.
         $project->getRepository()->getAll();
@@ -309,6 +310,7 @@ class EditCounterRepository extends Repository
      */
     protected function globalEditCountsFromDatabases(User $user, Project $project)
     {
+        $this->log->debug(__METHOD__." Getting global edit counts for ".$user->getUsername());
         $stopwatchName = 'globalRevisionCounts.'.$user->getUsername();
         $allProjects = $project->getRepository()->getAll();
         $topEditCounts = [];

--- a/web/static/js/autoedits.js
+++ b/web/static/js/autoedits.js
@@ -36,9 +36,9 @@ $(function () {
             end = $('.non-auto-edits-container').data('end'),
             namespace = $('.non-auto-edits-container').data('namespace');
 
-        /** global: xtBaseUrl */
+        /** global: xtApiUrl */
         $.ajax({
-            url: xtBaseUrl + 'api/user/nonautomated_edits/' + project + '/' + username + '/' +
+            url: xtApiUrl + 'api/user/nonautomated_edits/' + project + '/' + username + '/' +
                 namespace + '/' + start + '/' + end + '/' + editOffset + '?format=html',
             timeout: 30000
         }).done(function (data) {

--- a/web/static/js/editcounter.js
+++ b/web/static/js/editcounter.js
@@ -30,8 +30,8 @@ $(function () {
     // Only load if container is present, which is missing in subroutes, e.g. ec-namespacetotals, etc.
     var $latestGlobalContainer = $("#latestglobal-container");
     if ($latestGlobalContainer[0]) {
-        /** global: xtBaseUrl */
-        var url = xtBaseUrl + 'ec-latestglobal/'
+        /** global: xtApiUrl */
+        var url = xtApiUrl + 'ec-latestglobal/'
             + $latestGlobalContainer.data("project") + '/'
             + $latestGlobalContainer.data("username") + '?htmlonly=yes';
         $.ajax({


### PR DESCRIPTION
Due to the way curl works, we have to introduce a new parameter
that points to the app's base domain. This also allow us to
optionally use a different domain than the main app server, so
that you can offload resources to a dedicated API server.

Note we still need to document how to forward API requests to another server. See https://phabricator.wikimedia.org/T163284#3628215 for more.

I could not figure out a sane way to add tests for the async features :(

Bug: https://phabricator.wikimedia.org/T163284