### PR TITLE
EditCounter: show longest block as the duration, not expiry

### DIFF
--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -346,12 +346,12 @@
             <tr>
                 <td>{{ msg('block-longest') }}</td>
                 <td>
-                    {% if ec.longestBlockDays == -1 %}
+                    {% if ec.longestBlockSeconds == -1 %}
                         &#x221e; {# infinity #}
-                    {% elseif ec.longestBlockDays == false %}
+                    {% elseif ec.longestBlockSeconds == false %}
                         &ndash;
                     {% else %}
-                        {{ ec.longestBlockDays|number_format }} {{ msg('num-days', [ec.longestBlockDays]) }}
+                        {{ formatDuration(ec.longestBlockSeconds) }}
                     {% endif %}
                 </td>
             </tr>

--- a/src/Xtools/EditCounterRepository.php
+++ b/src/Xtools/EditCounterRepository.php
@@ -207,12 +207,13 @@ class EditCounterRepository extends Repository
     public function getBlocksReceived(Project $project, User $user)
     {
         $loggingTable = $this->getTableName($project->getDatabaseName(), 'logging', 'logindex');
-        $sql = "SELECT log_timestamp, log_params FROM $loggingTable
+        $sql = "SELECT log_action, log_timestamp, log_params FROM $loggingTable
                 WHERE log_type = 'block'
-                AND log_action = 'block'
+                AND log_action IN ('block', 'reblock', 'unblock')
                 AND log_timestamp > 0
                 AND log_title = :username
-                AND log_namespace = 2";
+                AND log_namespace = 2
+                ORDER BY log_timestamp ASC";
         $resultQuery = $this->getProjectsConnection()->prepare($sql);
         $username = str_replace(' ', '_', $user->getUsername());
         $resultQuery->bindParam('username', $username);


### PR DESCRIPTION
Loop through the block log to get the amount of time the user
was blocked.

Bug: https://phabricator.wikimedia.org/T174012