### PR TITLE
TopEdits: Show per-namespace breakdown if requested 'all' namespaces.

### DIFF
--- a/app/Resources/views/editCounter/result.html.twig
+++ b/app/Resources/views/editCounter/result.html.twig
@@ -78,11 +78,9 @@
         {{ layout.content_block(headerLink, content, '', 'timecard', true) }}
 
         {% set content %}
-            {{ render(path('TopEditsResults', {
-                'username': user.username,
-                'project': project.domain,
-                'namespace': 'all'
-            })) }}
+            <div id="topedits-container" data-username="{{ user.username }}" data-project="{{ project.domain }}">
+                <img src="{{ asset('static/images/loader.gif') }}" />
+            </div>
         {% endset %}
         {% set headerLink %}
             <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:'all'})}}">{{ msg('top-edited-pages') }}</a>

--- a/app/Resources/views/topedits/result_namespace.html.twig
+++ b/app/Resources/views/topedits/result_namespace.html.twig
@@ -10,56 +10,95 @@
         <div class="panel-body xt-panel-body" >
             {{ wiki.userLinks(user, project, xtPage) }}
             <h3 class="text-center">{{ msg('topedits-per-namespace') }}</h3>
-{% endif %}
-{% set content %}
-<table class="table table-bordered table-hover table-striped topedits-namespace-table" >
-    <thead><tr>
-        <th>
-            <span class="sort-link sort-link--edits" data-column="edits">
-                {{ msg('edits') | capitalize_first }}
-                <span class="glyphicon glyphicon-sort"></span>
-            </span>
-        </th>
-        <th>
-            <span class="sort-link sort-link--page" data-column="page">
-                {{ msg('page-title') }}
-                <span class="glyphicon glyphicon-sort"></span>
-            </span>
-        </th>
-        <th>{{ msg('links') }}</th>
-    </tr></thead>
-    <tbody>
-        {% for edit in edits %}
-        <tr>
-            <td class="sort-entry--edits tdnum" data-value="{{ edit.count }}">
-                {{ edit.count|num_format }}
-            </td>
-            <td class="sort-entry--page display-title" data-value="{{ edit.page_title_ns }}">
-                {{ wiki.pageLinkRaw(edit.page_title_ns, project, edit.displaytitle) }}
-            </td>
-            <td>
-                {{ wiki.pageLogLinkRaw(edit.page_title_ns, project) }}
-                &middot;
-                <a href="{{ path('ArticleInfoResult', {project:project.domain, article:edit.page_title_ns}) }}">{{ msg('tool-articleinfo') }}</a>
-                &middot;
-                <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:edit.page_namespace, article:edit.page_title}) }}" >{{ msg('tool-topedits') }}</a>
-            </td>
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
-{% endset %}
 
-{% if project.userHasOptedIn(user) %}
-    {% if is_sub_request %}
-        {{ content }}
-    {% else %}
-        {{ layout.content_block(nsName(namespace, project.namespaces), content, '', null, true, false) }}
-    {% endif %}
-{% else %}
+            {% if project.userHasOptedIn(user) and te.topEdits|length > 2 %}
+                <div class="text-center xt-toc">
+                    {#
+                     # To save real estate, show "Namespace (talk)" as separate links
+                     # instead of "Namespace" "Namespace talk".
+                     #}
+                    {% for ns in te.topEdits|keys if ns is even or (ns is odd and not(te.topEdits[ns - 1] is defined)) %}
+                        <span>
+                            <a href="#{{ ns }}" data-section="{{ ns }}">{{ nsName(ns, project.namespaces) }}</a>
+                            {% if te.topEdits[ns + 1] is defined %}
+                                (<a href="#{{ ns + 1 }}" data-section="{{ ns + 1 }}">{{ msg('talk')|lower }}</a>)
+                            {% endif %}
+                        </span>
+                    {% endfor %}
+                </div>
+            {% endif %}
+{% endif %}
+
+{% if not(project.userHasOptedIn(user)) %}
     <div class="alert alert-info">
         <p>{{ msg('not-opted-in', [ wiki.pageLink(opted_in_page) ]) }}</p>
     </div>
+{% else %}
+
+{% for ns, pages in te.topEdits %}
+    {% set content %}
+    <table class="table table-bordered table-hover table-striped topedits-namespace-table xt-show-hide--target">
+        <thead><tr>
+            <th>
+                <span class="sort-link sort-link--edits" data-column="edits">
+                    {{ msg('edits') | capitalize_first }}
+                    <span class="glyphicon glyphicon-sort"></span>
+                </span>
+            </th>
+            <th>
+                <span class="sort-link sort-link--page" data-column="page">
+                    {{ msg('page-title') }}
+                    <span class="glyphicon glyphicon-sort"></span>
+                </span>
+            </th>
+            <th>{{ msg('links') }}</th>
+        </tr></thead>
+        <tbody>
+            {% for page in pages %}
+            <tr>
+                <td class="sort-entry--edits tdnum" data-value="{{ page.count }}">
+                    {{ page.count|num_format }}
+                </td>
+                <td class="sort-entry--page display-title" data-value="{{ page.page_title_ns }}">
+                    {{ wiki.pageLinkRaw(page.page_title_ns, project, page.displaytitle) }}
+                </td>
+                <td>
+                    {{ wiki.pageLogLinkRaw(page.page_title_ns, project) }}
+                    &middot;
+                    <a href="{{ path('ArticleInfoResult', {project:project.domain, article:page.page_title_ns}) }}">{{ msg('tool-articleinfo') }}</a>
+                    &middot;
+                    <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:page.page_namespace, article:page.page_title}) }}" >{{ msg('tool-topedits') }}</a>
+                </td>
+            </tr>
+            {% endfor %}
+            {% if pages|length >= 10 and te.topEdits|length > 1 %}
+                <tr>
+                    <td colspan=3>
+                        <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:ns, article:''}) }}">
+                            {{ msg('more') }}&hellip;
+                        </a>
+                    </td>
+                </tr>
+            {% endif %}
+        </tbody>
+    </table>
+    {% endset %}
+
+    {% if is_sub_request %}
+        <h4 class="xt-show-hide--parent">
+            {{ nsName(ns, project.namespaces) }}
+            <small class='xt-show'>[{{ msg('show') | lower }}]</small>
+            <small class='xt-hide'>[{{ msg('hide') | lower }}]</small>
+        </h4>
+    {% endif %}
+
+    {% if is_sub_request %}
+        {{ content }}
+    {% else %}
+        {{ layout.content_block(nsName(ns, project.namespaces), content, '', ns, true, te.topEdits|length > 1) }}
+    {% endif %}
+{% endfor %}
+
 {% endif %}
 
 {% if not is_sub_request %}

--- a/src/Xtools/TopEdits.php
+++ b/src/Xtools/TopEdits.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * This file contains only the TopEdits class.
+ */
+
+namespace Xtools;
+
+use Symfony\Component\DependencyInjection\Container;
+use DateTime;
+
+/**
+ * TopEdits returns the top-edited pages by a user. There is not a separate
+ * repository because there is only one query :)
+ */
+class TopEdits extends Model
+{
+    /** @var Project The project. */
+    protected $project;
+
+    /** @var User The user. */
+    protected $user;
+
+    /** @var string[] Top edits object for quick caching, keyed by namespace ID. */
+    protected $topEdits = [];
+
+    /** @var int Number of rows to fetch. */
+    protected $limit;
+
+    /** @var int Which namespace we are querying for. */
+    protected $namespace;
+
+    const DEFAULT_LIMIT_SINGLE_NAMESPACE = 100;
+    const DEFAULT_LIMIT_ALL_NAMESPACES = 20;
+
+    /**
+     * TopEdits constructor.
+     * @param Project $project
+     * @param User $user
+     * @param string|int Namespace ID or 'all'.
+     * @param int $limit Number of rows to fetch. This defaults to
+     *   DEFAULT_LIMIT_SINGLE_NAMESPACE if $this->namespace is a single namespace (int),
+     *   and DEFAULT_LIMIT_ALL_NAMESPACES if $this->namespace is 'all'.
+     */
+    public function __construct(Project $project, User $user, $namespace = 0, $limit = null)
+    {
+        $this->project = $project;
+        $this->user = $user;
+        $this->namespace = $namespace === 'all' ? 'all' : (int)$namespace;
+
+        if ($limit) {
+            $this->limit = $limit;
+        } else {
+            $this->limit = $this->namespace === 'all'
+                ? self::DEFAULT_LIMIT_ALL_NAMESPACES
+                : self::DEFAULT_LIMIT_SINGLE_NAMESPACE;
+        }
+    }
+
+    /**
+     * Get the limit set on number of rows to fetch.
+     * @return int
+     */
+    public function getLimit()
+    {
+        return $this->limit;
+    }
+
+    /**
+     * Get the namespace set on the instance.
+     * @return int|string Namespace ID or 'all'.
+     */
+    public function getNamespace()
+    {
+        return $this->namespace;
+    }
+
+    /**
+     * Get the top edits by a user in the given namespace, or 'all' namespaces.
+     * This is the public function that should be used.
+     * @return string[] Results of self::getTopEditsByNamespace(), keyed by namespace.
+     */
+    public function getTopEdits()
+    {
+        if (count($this->topEdits) > 0) {
+            return $this->topEdits;
+        }
+
+        /** @var string[] The top edited pages, keyed by namespace ID. */
+        $topEditedPages = [];
+
+        /** @var int[] Which namespaces to iterate over. */
+        $namespaces = $this->namespace === 'all'
+            ? array_keys($this->project->getNamespaces())
+            : [$this->namespace];
+
+        foreach ($namespaces as $nsId) {
+            $pages = $this->getTopEditsByNamespace($nsId);
+
+            if (count($pages)) {
+                $topEditedPages[$nsId] = $pages;
+            }
+        }
+
+        $this->topEdits = $topEditedPages;
+        return $topEditedPages;
+    }
+
+    /**
+     * Get the top edits by a user in the given namespace.
+     * @param int $namespace Namespace ID.
+     * @return string[] page_namespace, page_title, page_is_redirect,
+     *   count (number of edits), assessment (page assessment).
+     */
+    protected function getTopEditsByNamespace($namespace = 0)
+    {
+        $topPages = $this->getRepository()->getTopEdits(
+            $this->project,
+            $this->user,
+            $namespace,
+            $this->limit
+        );
+
+        // Display titles need to be fetched ahead of time.
+        $displayTitles = $this->getDisplayTitles($topPages);
+
+        $pages = [];
+        foreach ($topPages as $page) {
+            // If non-mainspace, prepend namespace to the titles.
+            $ns = (int) $page['page_namespace'];
+            $nsTitle = $ns > 0 ? $this->project->getNamespaces()[$page['page_namespace']] . ':' : '';
+            $pageTitle = $nsTitle . $page['page_title'];
+            $page['displaytitle'] = $displayTitles[$pageTitle];
+            // $page['page_title'] is retained without the namespace
+            //  so we can link to TopEdits for that page.
+            $page['page_title_ns'] = $pageTitle;
+            $pages[] = $page;
+        }
+
+        return $pages;
+    }
+
+    /**
+     * Get the display titles of the given pages.
+     * @param  string[] $topPages As returned by $this->getRepository()->getTopEdits()
+     * @return string[] Keys are the original supplied titles, and values are the display titles.
+     */
+    private function getDisplayTitles($topPages)
+    {
+        $namespaces = $this->project->getNamespaces();
+
+        // First extract page titles including namespace.
+        $pageTitles = array_map(function ($page) use ($namespaces) {
+            // If non-mainspace, prepend namespace to the titles.
+            $ns = $page['page_namespace'];
+            $nsTitle = $ns > 0 ? $namespaces[$page['page_namespace']] . ':' : '';
+            return $nsTitle . $page['page_title'];
+        }, $topPages);
+
+        return $this->getRepository()->getDisplayTitles($this->project, $pageTitles);
+    }
+}

--- a/src/Xtools/TopEditsRepository.php
+++ b/src/Xtools/TopEditsRepository.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file contains only the TopEditsRepository class.
+ */
+
+namespace Xtools;
+
+use DateInterval;
+
+/**
+ * TopEditsRepository is responsible for retrieving data from the database
+ * about the top-edited pages of a user. It doesn't do any post-processing
+ * of that information. There's really only one query here, but for testing
+ * purposes we want this in a separate file.
+ */
+class TopEditsRepository extends Repository
+{
+    /**
+     * Get the top edits by a user in the given namespace.
+     * @param Project $project
+     * @param User $user
+     * @param int $namespace Namespace ID.
+     * @param int $limit Number of edits to fetch.
+     * @return string[] page_namespace, page_title, page_is_redirect,
+     *   count (number of edits), assessment (page assessment).
+     */
+    public function getTopEdits(Project $project, User $user, $namespace = 0, $limit = 100)
+    {
+        // Set up cache.
+        $cacheKey = 'topedits.'.$project->getDatabaseName().'.'.$user->getCacheKey().
+            $namespace.$limit;
+        if ($this->cache->hasItem($cacheKey)) {
+            return $this->cache->getItem($cacheKey)->get();
+        }
+
+        $pageTable = $this->getTableName($project->getDatabaseName(), 'page');
+        $revisionTable = $this->getTableName($project->getDatabaseName(), 'revision');
+
+        $hasPageAssessments = $this->isLabs() && $project->hasPageAssessments() && $namespace === 0;
+        $pageAssessmentsTable = $this->getTableName($project->getDatabaseName(), 'page_assessments');
+        $paJoin = $hasPageAssessments ? "LEFT JOIN $pageAssessmentsTable ON rev_page = pa_page_id" : '';
+        $paSelects = $hasPageAssessments ? ', pa_class' : '';
+
+        $sql = "SELECT page_namespace, page_title, page_is_redirect, COUNT(page_title) AS count
+                    $paSelects
+                FROM $pageTable JOIN $revisionTable ON page_id = rev_page
+                $paJoin
+                WHERE rev_user_text = :username
+                AND page_namespace = :namespace
+                GROUP BY page_namespace, page_title
+                ORDER BY count DESC
+                LIMIT $limit";
+        $resultQuery = $this->getProjectsConnection()->prepare($sql);
+        $username = $user->getUsername();
+        $resultQuery->bindParam('username', $username);
+        $resultQuery->bindParam('namespace', $namespace);
+        $resultQuery->execute();
+        $results = $resultQuery->fetchAll();
+
+        // Cache for 10 minutes, and return.
+        $cacheItem = $this->cache->getItem($cacheKey)
+            ->set($results)
+            ->expiresAfter(new DateInterval('PT10M'));
+        $this->cache->save($cacheItem);
+
+        return $results;
+    }
+
+    /**
+     * Get the display titles of the given pages.
+     * @param Project $project
+     * @param  string[] $titles List of page titles.
+     * @return string[] Keys are the original supplied titles, and values are the display titles.
+     */
+    public function getDisplayTitles(Project $project, $titles)
+    {
+        /** @var ApiHelper $apiHelper */
+        $apiHelper = $this->container->get('app.api_helper');
+
+        return $apiHelper->displayTitles($project->getDomain(), $titles);
+    }
+}

--- a/tests/Xtools/TopEditsTest.php
+++ b/tests/Xtools/TopEditsTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This file contains only the TopEdits class.
+ */
+
+namespace Tests\Xtools;
+
+use PHPUnit_Framework_TestCase;
+use Xtools\TopEdits;
+use Xtools\TopEditsRepository;
+use Xtools\User;
+use Xtools\Project;
+use Xtools\ProjectRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Tests of the Edit class.
+ */
+class TopEditsTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Project The project instance. */
+    protected $project;
+
+    /** @var ProjectRepository The project repo instance. */
+    protected $projectRepo;
+
+    /** @var TopEditsRepository The TopEdits repo instance. */
+    protected $teRepo;
+
+    /** @var User The user instance. */
+    protected $user;
+
+    /**
+     * Set up container, class instances and mocks.
+     */
+    public function setUp()
+    {
+        $this->project = new Project('TestProject');
+        $this->projectRepo = $this->getMock(ProjectRepository::class);
+        $this->projectRepo->method('getMetadata')
+            ->willReturn(['namespaces' => [0 => 'Main', 3 => 'User_talk']]);
+        $this->project->setRepository($this->projectRepo);
+        $this->user = new User('Test user');
+
+        $this->teRepo = $this->getMock(TopEditsRepository::class);
+    }
+
+    /**
+     * Test the basic functionality of Edit.
+     */
+    public function testBasic()
+    {
+        // Single namespace, with defaults.
+        $te = new TopEdits($this->project, $this->user);
+        $this->assertEquals(0, $te->getNamespace());
+        $this->assertEquals(100, $te->getLimit());
+
+        // Single namespace, explicit configuration.
+        $te2 = new TopEdits($this->project, $this->user, 5, 50);
+        $this->assertEquals(5, $te2->getNamespace());
+        $this->assertEquals(50, $te2->getLimit());
+
+        // All namespaces, so limit set.
+        $te3 = new TopEdits($this->project, $this->user, 'all');
+        $this->assertEquals('all', $te3->getNamespace());
+        $this->assertEquals(20, $te3->getLimit());
+
+        // All namespaces, explicit limit.
+        $te4 = new TopEdits($this->project, $this->user, 'all', 3);
+        $this->assertEquals('all', $te4->getNamespace());
+        $this->assertEquals(3, $te4->getLimit());
+    }
+
+    /**
+     * Main getTopEdits method.
+     */
+    public function testTopEdits()
+    {
+        $te = new TopEdits($this->project, $this->user, 'all', 2);
+        $this->teRepo->expects($this->exactly(2))
+            ->method('getTopEdits')
+            ->withConsecutive(
+                [$this->project, $this->user, 0, 2],
+                [$this->project, $this->user, 3, 2]
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->topEditsRepoFactory()[0],
+                $this->topEditsRepoFactory()[3]
+            );
+        $te->setRepository($this->teRepo);
+
+        $result = $te->getTopEdits();
+        $this->assertEquals([0, 3], array_keys($result));
+        $this->assertEquals(2, count($result));
+        $this->assertEquals(2, count($result[0]));
+        $this->assertEquals(2, count($result[3]));
+        $this->assertEquals([
+            'page_namespace' => '0',
+            'page_title' => 'Foo_bar',
+            'page_is_redirect' => '1',
+            'count' => '24',
+            'pa_class' => 'List',
+            'displaytitle' => null,
+            'page_title_ns' => 'Foo_bar',
+        ], $result[0][0]);
+    }
+
+    /**
+     * Data for self::testTopEdits().
+     * @return string[]
+     */
+    public function topEditsRepoFactory()
+    {
+        return [
+            0 => [
+                [
+                  'page_namespace' => '0',
+                  'page_title' => 'Foo_bar',
+                  'page_is_redirect' => '1',
+                  'count' => '24',
+                  'pa_class' => 'List',
+                  'displaytitle' => 'Foo bar',
+                  'page_title_ns' => 'Foo_bar',
+                ], [
+                  'page_namespace' => '0',
+                  'page_title' => '101st_Airborne_Division',
+                  'page_is_redirect' => '0',
+                  'count' => '18',
+                  'pa_class' => 'C',
+                  'displaytitle' => '101st Airborne Division',
+                  'page_title_ns' => '101st_Airborne_Division',
+                ],
+            ],
+            3 => [
+                [
+                  'page_namespace' => '3',
+                  'page_title' => 'Test_user_1',
+                  'page_is_redirect' => '0',
+                  'count' => '3',
+                  'displaytitle' => 'User talk:Test user 1',
+                  'page_title_ns' => 'User talk:Test_user_1',
+                ], [
+                  'page_namespace' => '3',
+                  'page_title' => 'Jimbo_Wales',
+                  'page_is_redirect' => '0',
+                  'count' => '1',
+                  'displaytitle' => '<i>User talk:Jimbo Wales</i>',
+                  'page_title_ns' => 'User talk:Jimbo_Wales',
+                ],
+            ],
+        ];
+    }
+}

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -19,15 +19,26 @@
     }).load(messagesToLoad);
 
     $(document).ready(function () {
+        // TODO: move these listeners to a setup function and document how to use it.
         $('.xt-hide').on('click', function () {
             $(this).hide();
             $(this).siblings('.xt-show').show();
-            $(this).parents('.panel-heading').siblings('.panel-body').hide();
+
+            if ($(this).parents('.panel-heading').length) {
+                $(this).parents('.panel-heading').siblings('.panel-body').hide();
+            } else {
+                $(this).parents('.xt-show-hide--parent').next('.xt-show-hide--target').hide();
+            }
         });
         $('.xt-show').on('click', function () {
             $(this).hide();
             $(this).siblings('.xt-hide').show();
-            $(this).parents('.panel-heading').siblings('.panel-body').show();
+
+            if ($(this).parents('.panel-heading').length) {
+                $(this).parents('.panel-heading').siblings('.panel-body').show();
+            } else {
+                $(this).parents('.xt-show-hide--parent').next('.xt-show-hide--target').show();
+            }
         });
 
         setupNavCollapsing();

--- a/web/static/js/editcounter.js
+++ b/web/static/js/editcounter.js
@@ -26,14 +26,34 @@ $(function () {
         return undefined;
     });
 
+    // Load top edits HTML via AJAX, to not slow down the initial page load.
+    // Only load if container is present, which is missing in subroutes, e.g. ec-namespacetotals, etc.
+    var $topEditsContainer = $("#topedits-container");
+    if ($topEditsContainer[0]) {
+        /** global: xtBaseUrl */
+        var url = xtBaseUrl + 'topedits/'
+            + $topEditsContainer.data('project') + '/'
+            + $topEditsContainer.data('username') + '/all?htmlonly=yes';
+        $.ajax({
+            url: url,
+            timeout: 30000
+        }).done(function (data) {
+            $topEditsContainer.replaceWith(data);
+        }).fail(function (_xhr, _status, message) {
+            $topEditsContainer.replaceWith(
+                $.i18n('api-error', 'TopEdits API: <code>' + message + '</code>')
+            );
+        });
+    }
+
     // Load recent global edits' HTML via AJAX, to not slow down the initial page load.
     // Only load if container is present, which is missing in subroutes, e.g. ec-namespacetotals, etc.
     var $latestGlobalContainer = $("#latestglobal-container");
     if ($latestGlobalContainer[0]) {
         /** global: xtBaseUrl */
         var url = xtBaseUrl + 'ec-latestglobal/'
-            + $latestGlobalContainer.data("project") + '/'
-            + $latestGlobalContainer.data("username") + '?htmlonly=yes';
+            + $latestGlobalContainer.data('project') + '/'
+            + $latestGlobalContainer.data('username') + '?htmlonly=yes';
         $.ajax({
             url: url,
             timeout: 30000


### PR DESCRIPTION
EditCounter: Load 'all' TopEdits asynchronously with AJAX.

Bug: https://phabricator.wikimedia.org/T177730