### PR TITLE
EditCounter: Make bars of month and year charts consistent

### DIFF
--- a/app/Resources/views/editCounter/monthcounts.html.twig
+++ b/app/Resources/views/editCounter/monthcounts.html.twig
@@ -30,7 +30,7 @@
 {% else %}
 
 {# Set height of chart based on how many months (horizontal rows) are being reported. #}
-<div style="position:relative; height:{{ 35 * ec.monthCounts.monthLabels|length }}px">
+<div style="position:relative; height:{{ (25 * ec.monthCounts.monthLabels|length) + 30 }}px">
     <canvas id="monthcounts-canvas"></canvas>
 </div>
 

--- a/app/Resources/views/editCounter/namespace_totals.html.twig
+++ b/app/Resources/views/editCounter/namespace_totals.html.twig
@@ -23,7 +23,7 @@
                 <div class="panel-body col-lg-12">
 {% endif %}
 
-<table class="table table-bordered table-hover table-striped tools-table toggle-table">
+<table class="table table-bordered table-hover table-striped namespaces-table toggle-table">
     <thead>
         {% for key in ['namespace', 'count'] %}
             <th>
@@ -35,7 +35,9 @@
         {% endfor %}
     </thead>
     <tbody>
+        {% set availableNamespaces = [] %}
         {% for nsId, value in ec.namespaceTotals %}
+            {% set availableNamespaces = availableNamespaces|merge([nsId]) %}
             <tr>
                 <td class="sort-entry--namespace" data-value="{{ nsId }}">
                     <span class="tools-toggle toggle-table--toggle" data-index="{{ loop.index0 }}" data-key="{{ nsId }}">
@@ -65,6 +67,7 @@
 <div class="chart-wrapper namespaces-chart-wrapper toggle-table--chart">
     <canvas id="namespace-canvas"></canvas>
     <script>
+        window.namespaces = {{ project.namespaces|json_encode()|raw }};
         window.namespaceTotals = {{ ec.namespaceTotals|json_encode()|raw }};
         window.namespaceChart = new Chart($("#namespace-canvas"), {
             type: 'pie',

--- a/app/Resources/views/editCounter/yearcounts.html.twig
+++ b/app/Resources/views/editCounter/yearcounts.html.twig
@@ -24,7 +24,7 @@
 {% endif %}
 
 {# Set height of chart based on how many years (horizontal rows) are being reported. #}
-<div style="position:relative; height:{{ 45 * ec.yearCounts.yearLabels|length }}px">
+<div style="position:relative; height:{{ (25 * ec.yearCounts.yearLabels|length) + 30 }}px">
     <canvas id="yearcounts-canvas"></canvas>
 </div>
 <script type="text/javascript">

--- a/web/static/css/editcounter.scss
+++ b/web/static/css/editcounter.scss
@@ -13,7 +13,9 @@
         }
     }
 
-    #timecard-bubble-chart {
+    #timecard-bubble-chart,
+    #yearcounts-canvas,
+    #monthcounts-canvas {
         max-width: 1000px;
     }
 

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -106,7 +106,9 @@
      *                                   { 'a' => 123, 'b' => 456 }
      * @param  {Function} updateCallback Callback to update the .toggle-table totals. `toggleTableData`
      *                                   is passed in which contains the new data, you just need to
-     *                                   format it (maybe need to use i18n, update multiple cells, etc.)
+     *                                   format it (maybe need to use i18n, update multiple cells, etc.).
+     *                                   The second parameter that is passed back is the 'key' of the toggled
+     *                                   item, and the third is the index of the item.
      */
     window.setupToggleTable = function (dataSource, chartObj, valueKey, updateCallback) {
         $('.toggle-table').on('click', '.toggle-table--toggle', function () {
@@ -137,7 +139,7 @@
             $(this).find('.glyphicon').toggleClass('glyphicon-remove').toggleClass('glyphicon-plus');
 
             // update stats
-            updateCallback(toggleTableData);
+            updateCallback(toggleTableData, key, index);
 
             chartObj.update();
         });

--- a/web/static/js/editcounter.js
+++ b/web/static/js/editcounter.js
@@ -1,3 +1,22 @@
+/**
+ * Namespaces that have been excluded from view via namespace toggle table.
+ * @type {Array}
+ */
+window.excludedNamespaces = [];
+
+/**
+ * Chart labels for the month/yearcount charts.
+ * @type {Object} Keys are the chart IDs, values are arrays of strings.
+ */
+window.chartLabels = {};
+
+/**
+ * Number of digits of the max month/year total. We want to keep this consistent
+ * for aesthetic reasons, even if the updated totals are fewer digits in size.
+ * @type {Object} Keys are the chart IDs, values are integers.
+ */
+window.maxDigits = {};
+
 $(function () {
     // Don't do anything if this isn't a Edit Counter page.
     if ($("body.ec").length === 0) {
@@ -5,14 +24,14 @@ $(function () {
     }
 
     // Set up charts.
-    $(".chart-wrapper").each(function () {
-        var chartType = $(this).data("chart-type");
+    $('.chart-wrapper').each(function () {
+        var chartType = $(this).data('chart-type');
         if ( chartType === undefined ) {
             return false;
         }
-        var data = $(this).data("chart-data");
-        var labels = $(this).data("chart-labels");
-        var $ctx = $("canvas", $(this));
+        var data = $(this).data('chart-data');
+        var labels = $(this).data('chart-labels');
+        var $ctx = $('canvas', $(this));
 
         /** global: Chart */
         new Chart($ctx, {
@@ -29,19 +48,76 @@ $(function () {
     loadLatestGlobal();
 
     // Set up namespace toggle chart.
-    setupToggleTable(window.namespaceTotals, window.namespaceChart, null, function (newData) {
-        var total = 0;
-        Object.keys(newData).forEach(function (namespace) {
-            total += parseInt(newData[namespace], 10);
-        });
-        var namespaceCount = Object.keys(newData).length;
-        $('.namespaces--namespaces').text(
-            namespaceCount.toLocaleString() + " " +
-            $.i18n('num-namespaces', namespaceCount)
-        );
-        $('.namespaces--count').text(total.toLocaleString());
-    });
+    setupToggleTable(window.namespaceTotals, window.namespaceChart, null, toggleNamespace);
 });
+
+/**
+ * Callback for setupToggleTable(). This will show/hide a given namespace from
+ * all charts, and update totals and percentages.
+ * @param  {Object} newData New namespaces and totals, as returned by setupToggleTable.
+ * @param  {String} key     Namespace ID of the toggled namespace.
+ */
+function toggleNamespace(newData, key)
+{
+    var total = 0, counts = [];
+    Object.keys(newData).forEach(function (namespace) {
+        var count = parseInt(newData[namespace], 10);
+        counts.push(count);
+        total += count;
+    });
+    var namespaceCount = Object.keys(newData).length;
+
+    $('.namespaces--namespaces').text(
+        namespaceCount.toLocaleString() + ' ' +
+        $.i18n('num-namespaces', namespaceCount)
+    );
+    $('.namespaces--count').text(total.toLocaleString());
+
+    // Now that we have the total, loop through once more time to update percentages.
+    counts.forEach(function (count) {
+        // Calculate percentage, rounded to tenths.
+        var percentage = +(Math.round(
+            ((count / total) * 100) + 'e+1'
+        ) + 'e-1');
+        // Update text with new value and percentage.
+        $('.namespaces-table .sort-entry--count[data-value='+count+']').text(
+            count.toLocaleString() + ' (' + percentage + '%)'
+        );
+    });
+
+    // Loop through month and year charts, toggling the dataset for the newly excluded namespace.
+    ['year', 'month'].forEach(function (id) {
+        var chartObj = window[id + 'countsChart'],
+            nsName = window.namespaces[key] || $.i18n('mainspace');
+
+        // Figure out the index of the namespace we're toggling within this chart object.
+        var datasetIndex;
+        chartObj.data.datasets.forEach(function (dataset, i) {
+            if (dataset.label === nsName) {
+                datasetIndex = i;
+            }
+        });
+
+        // Fetch the metadata and toggle the hidden property.
+        var meta = chartObj.getDatasetMeta(datasetIndex);
+        meta.hidden = meta.hidden === null ? !chartObj.data.datasets[datasetIndex].hidden : null;
+
+        // Add this namespace to the list of excluded namespaces.
+        if (meta.hidden) {
+            window.excludedNamespaces.push(nsName);
+        } else {
+            window.excludedNamespaces = window.excludedNamespaces.filter(function (namespace) {
+                return namespace !== nsName;
+            });
+        }
+
+        // Update y-axis labels with the new totals.
+        window[id + 'countsChart'].config.data.labels = getYAxisLabels(id, chartObj.data.datasets);
+
+        // Refresh chart.
+        chartObj.update();
+    });
+}
 
 /**
  * Load recent global edits' HTML via AJAX, to not slow down the initial page load.
@@ -70,72 +146,64 @@ function loadLatestGlobal()
 }
 
 /**
- * Set up the monthcounts or yearcounts chart.
+ * Build the labels for the y-axis of the year/monthcount charts,
+ * which include the year/month and the total number of edits across
+ * all namespaces in that year/month.
+ * @param {String} id ID prefix of the chart, either 'month' or 'year'.
+ * @param {Array} datasets Datasets making up the chart.
+ */
+function getYAxisLabels(id, datasets)
+{
+    var labelsAndTotals = {};
+    datasets.forEach(function (namespace) {
+        if (window.excludedNamespaces.indexOf(namespace.label) !== -1) {
+            return;
+        }
+
+        namespace.data.forEach(function (count, index) {
+            if (!labelsAndTotals[window.chartLabels[id][index]]) {
+                labelsAndTotals[window.chartLabels[id][index]] = 0;
+            }
+            labelsAndTotals[window.chartLabels[id][index]] += count;
+        });
+    });
+
+    // Format labels with totals next to them. This is a bit hacky,
+    // but it works! We use tabs (\t) to make the labels/totals
+    // for each namespace line up perfectly.
+    // The caveat is that we can't localize the numbers because
+    // the commas are not monospaced :(
+    return Object.keys(labelsAndTotals).map(function (year) {
+        var digitCount = labelsAndTotals[year].toString().length;
+        var numTabs = (window.maxDigits[id] - digitCount) * 2;
+
+        // +5 for a bit of extra spacing.
+        return year + Array(numTabs + 5).join("\t") +
+            labelsAndTotals[year];
+    });
+}
+
+/**
+ * Set up the monthcounts or yearcounts chart. This is set on the window
+ * because it is called in the yearcounts/monthcounts view.
  * @param {String} id 'year' or 'month'.
  * @param {Array} datasets Datasets grouped by mainspace.
  * @param {Array} labels The bare labels for the y-axis (years or months).
  * @param {Number} maxTotal Maximum value of year/month totals.
  */
 window.setupMonthYearChart = function (id, datasets, labels, maxTotal) {
-    /**
-     * Namespaces that have been excluded from view via clickable
-     * labels above the chart.
-     * @type {Array}
-     */
-    var excludedNamespaces = [];
-
-    /**
-     * Number of digits of the max month/year total. We want to keep this consistent
-     * for aesthetic reasons, even if the updated totals are fewer digits in size.
-     * @type {Number}
-     */
-    var maxDigits = maxTotal.toString().length;
-
     /** @type {Array} Labels for each namespace. */
     var namespaces = datasets.map(function (dataset) {
         return dataset.label;
     });
 
-    /**
-     * Build the labels for the y-axis of the year/monthcount charts,
-     * which include the year/month and the total number of edits across
-     * all namespaces in that year/month.
-     */
-    function getYAxisLabels()
-    {
-        var labelsAndTotals = {};
-        datasets.forEach(function (namespace) {
-            if (excludedNamespaces.indexOf(namespace.label) !== -1) {
-                return;
-            }
-
-            namespace.data.forEach(function (count, index) {
-                if (!labelsAndTotals[labels[index]]) {
-                    labelsAndTotals[labels[index]] = 0;
-                }
-                labelsAndTotals[labels[index]] += count;
-            });
-        });
-
-        // Format labels with totals next to them. This is a bit hacky,
-        // but it works! We use tabs (\t) to make the labels/totals
-        // for each namespace line up perfectly.
-        // The caveat is that we can't localize the numbers because
-        // the commas are not monospaced :(
-        return Object.keys(labelsAndTotals).map(function (year) {
-            var digitCount = labelsAndTotals[year].toString().length;
-            var numTabs = (maxDigits - digitCount) * 2;
-
-            // +5 for a bit of extra spacing.
-            return year + Array(numTabs + 5).join("\t") +
-                labelsAndTotals[year];
-        });
-    }
+    window.maxDigits[id] = maxTotal.toString().length
+    window.chartLabels[id] = labels;
 
     window[id + 'countsChart'] = new Chart($('#' + id + 'counts-canvas'), {
         type: 'horizontalBar',
         data: {
-            labels: getYAxisLabels(),
+            labels: getYAxisLabels(id, datasets),
             datasets: datasets
         },
         options: {
@@ -166,28 +234,12 @@ window.setupMonthYearChart = function (id, datasets, labels, maxTotal) {
                     }
                 }],
                 yAxes: [{
-                    stacked: true
+                    stacked: true,
+                    barThickness: 18,
                 }]
             },
             legend: {
-                // Happens when the user enables/disables a namespace via the
-                // labels above the chart.
-                onClick: function (e, legendItem) {
-                    // Update totals, skipping over namespaces that have been excluded.
-                    if (legendItem.hidden) {
-                        excludedNamespaces = excludedNamespaces.filter(function (namespace) {
-                            return namespace !== legendItem.text;
-                        });
-                    } else {
-                        excludedNamespaces.push(legendItem.text);
-                    }
-
-                    // Update labels with the new totals.
-                    window[id + 'countsChart'].config.data.labels = getYAxisLabels();
-
-                    // Yield to default onClick event, which re-renders the chart.
-                    Chart.defaults.global.legend.onClick.call(this, e, legendItem);
-                }
+                display: false
             }
         }
     });


### PR DESCRIPTION
Remove legends from year/month charts, instead using the namespace table
to toggle namespaces. When toggled, update the percentages in the table
and show/hide the dataset from the year and month charts.

Bug: https://phabricator.wikimedia.org/T174581