### PR TITLE
TopEdits: Speed up by getting 'all' namespaces with a single query.

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -68,7 +68,7 @@ parameters:
     enable.bash: 0
     enable.blame: 0
     enable.ec: 1
-    enable.es: 0
+    enable.es: 1
     enable.pages: 1
     enable.rfx: 0
     enable.rfxvote: 0

--- a/src/Xtools/TopEditsRepository.php
+++ b/src/Xtools/TopEditsRepository.php
@@ -10,13 +10,12 @@ use DateInterval;
 /**
  * TopEditsRepository is responsible for retrieving data from the database
  * about the top-edited pages of a user. It doesn't do any post-processing
- * of that information. There's really only one query here, but for testing
- * purposes we want this in a separate file.
+ * of that information.
  */
 class TopEditsRepository extends Repository
 {
     /**
-     * Get the top edits by a user in the given namespace.
+     * Get the top edits by a user in a single namespace.
      * @param Project $project
      * @param User $user
      * @param int $namespace Namespace ID.
@@ -24,7 +23,7 @@ class TopEditsRepository extends Repository
      * @return string[] page_namespace, page_title, page_is_redirect,
      *   count (number of edits), assessment (page assessment).
      */
-    public function getTopEdits(Project $project, User $user, $namespace = 0, $limit = 100)
+    public function getTopEditsNamespace(Project $project, User $user, $namespace = 0, $limit = 100)
     {
         // Set up cache.
         $cacheKey = 'topedits.'.$project->getDatabaseName().'.'.$user->getCacheKey().
@@ -59,6 +58,70 @@ class TopEditsRepository extends Repository
         $username = $user->getUsername();
         $resultQuery->bindParam('username', $username);
         $resultQuery->bindParam('namespace', $namespace);
+        $resultQuery->execute();
+        $results = $resultQuery->fetchAll();
+
+        // Cache for 10 minutes, and return.
+        $cacheItem = $this->cache->getItem($cacheKey)
+            ->set($results)
+            ->expiresAfter(new DateInterval('PT10M'));
+        $this->cache->save($cacheItem);
+
+        return $results;
+    }
+
+    /**
+     * Get the top edits by a user across all namespaces.
+     * @param Project $project
+     * @param User $user
+     * @param int $limit Number of edits to fetch.
+     * @return string[] page_namespace, page_title, page_is_redirect,
+     *   count (number of edits), assessment (page assessment).
+     */
+    public function getTopEditsAllNamespaces(Project $project, User $user, $limit = 10)
+    {
+        // Set up cache.
+        $cacheKey = 'topedits.'.$project->getDatabaseName().'.'.$user->getCacheKey().
+            'all'.$limit;
+        if ($this->cache->hasItem($cacheKey)) {
+            return $this->cache->getItem($cacheKey)->get();
+        }
+
+        $pageTable = $this->getTableName($project->getDatabaseName(), 'page');
+        $revisionTable = $this->getTableName($project->getDatabaseName(), 'revision');
+        $hasPageAssessments = $this->isLabs() && $project->hasPageAssessments();
+        $pageAssessmentsTable = $this->getTableName($project->getDatabaseName(), 'page_assessments');
+        $paSelect = $hasPageAssessments
+            ?  ", (
+                    SELECT pa_class
+                    FROM $pageAssessmentsTable
+                    WHERE pa_page_id = e.page_id
+                    LIMIT 1
+                ) AS pa_class"
+            : ', NULL as pa_class';
+
+        $sql = "SELECT c.page_namespace, e.page_title, c.count $paSelect
+                FROM
+                (
+                    SELECT b.page_namespace, b.rev_page, b.count
+                        ,@rn := if(@ns = b.page_namespace, @rn + 1, 1) AS row_number
+                        ,@ns := b.page_namespace AS dummy
+                    FROM
+                    (
+                        SELECT page_namespace, rev_page, count(rev_page) AS count
+                        FROM $revisionTable
+                        JOIN $pageTable ON page_id = rev_page
+                        WHERE rev_user_text = :username
+                        GROUP BY page_namespace, rev_page
+                    ) AS b
+                    JOIN (SELECT @ns := NULL, @rn := 0) AS vars
+                    ORDER BY b.page_namespace ASC, b.count DESC
+                ) AS c
+                JOIN $pageTable e ON e.page_id = c.rev_page
+                WHERE c.row_number < $limit";
+        $resultQuery = $this->getProjectsConnection()->prepare($sql);
+        $username = $user->getUsername();
+        $resultQuery->bindParam('username', $username);
         $resultQuery->execute();
         $results = $resultQuery->fetchAll();
 

--- a/tests/AppBundle/Controller/ApiControllerTest.php
+++ b/tests/AppBundle/Controller/ApiControllerTest.php
@@ -139,7 +139,7 @@ class ApiControllerTest extends WebTestCase
         $this->assertContains('text/html', $response->headers->get('content-type'));
 
         // Test again for too many edits.
-        $url = '/api/user/nonautomated_edits/en.wikipedia/Widr/0';
+        $url = '/api/user/nonautomated_edits/en.wikipedia/Materialscientist/0';
         $crawler = $this->client->request('GET', $url);
         $response = $this->client->getResponse();
         $this->assertEquals(403, $response->getStatusCode());

--- a/tests/AppBundle/Controller/DefaultControllerTest.php
+++ b/tests/AppBundle/Controller/DefaultControllerTest.php
@@ -34,6 +34,6 @@ class DefaultControllerTest extends WebTestCase
         );
 
         // Make sure all active tools are listed.
-        $this->assertCount(8, $crawler->filter('.tool-list a.btn'));
+        $this->assertCount(9, $crawler->filter('.tool-list a.btn'));
     }
 }


### PR DESCRIPTION
Fixes to make tests pass locally.

Bug: https://phabricator.wikimedia.org/T177883