### PR TITLE
Don't include reverted edits when showing top editors

### DIFF
--- a/app/Resources/views/articleInfo/result.html.twig
+++ b/app/Resources/views/articleInfo/result.html.twig
@@ -371,7 +371,7 @@
                 <tbody>
                 {% set counter = 0 %}
                 {% set editSum = 0 %}
-                {% for editor, stats in ai.editors|slice(0, editorlimit ) %}
+                {% for editor, stats in ai.editors if counter < editorlimit and not(editor in ai.bots|keys) %}
                     {% set counter = counter + 1 %}
                     {% set editSum = editSum + stats.all %}
                     <tr>

--- a/src/AppBundle/Controller/TopEditsController.php
+++ b/src/AppBundle/Controller/TopEditsController.php
@@ -82,7 +82,8 @@ class TopEditsController extends XtoolsController
     public function resultAction(Request $request, $namespace = 0, $article = '')
     {
         // Second parameter causes it return a Redirect to the index if the user has too many edits.
-        $ret = $this->validateProjectAndUser($request, 'topedits');
+        // We only want to do this when looking at the user's overall edits, not just to a specific article.
+        $ret = $this->validateProjectAndUser($request, $article !== '' ?  null : 'topedits');
         if ($ret instanceof RedirectResponse) {
             return $ret;
         } else {


### PR DESCRIPTION
Don't include bots in top editors either

Bug: https://phabricator.wikimedia.org/T179762