### PR TITLE
Link to Result pages where approrpriate, instead of index

### DIFF
--- a/app/Resources/views/articleInfo/api.html.twig
+++ b/app/Resources/views/articleInfo/api.html.twig
@@ -16,8 +16,8 @@
 {% if data.error is not defined -%}
     {{ msg('comma-character') }}
     {{ msg('created-by')|lower }}: {{ wiki.userLink(data.author, project) }}
-    (<a target="_blank" href="{{ url('ec', { 'project': project.domain, 'username': data.author }) }}">{{ data.author_editcount|num_format }}</a>)
+    (<a target="_blank" href="{{ url('EditCounterResult', { 'project': project.domain, 'username': data.author }) }}">{{ data.author_editcount|num_format }}</a>)
 {% endif %}
  &middot;
-<a target="_blank" href="{{ url('articleinfo', { 'project': project.domain, 'article': page.title }) }}">{{ msg('see-full-page-stats') }}</a>
+<a target="_blank" href="{{ url('ArticleInfoResult', { 'project': project.domain, 'article': page.title }) }}">{{ msg('see-full-page-stats') }}</a>
 </span>

--- a/app/Resources/views/articleInfo/result.html.twig
+++ b/app/Resources/views/articleInfo/result.html.twig
@@ -474,11 +474,11 @@
                         </td>
                         <td>
                             {% if enabled('topedits') %}
-                                <a href="{{ path('topedits', { 'project': project.domain, 'username': editor, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
+                                <a href="{{ path('TopEditsResult', { 'project': project.domain, 'username': editor, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
                             {% endif %}
                             &middot;
                             {% if enabled('ec') %}
-                                <a href="{{ path('ec', { 'project': project.domain, 'username': editor }) }}">{{ msg('tool-ec') }}</a>
+                                <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': editor }) }}">{{ msg('tool-ec') }}</a>
                             {% endif %}
                         </td>
                         <td class="sort-entry--edits" data-value="{{ stats.all }}">
@@ -552,11 +552,11 @@
                         </td>
                         <td>
                             {% if enabled('topedits') %}
-                                <a href="{{ path('topedits', { 'project': project.domain, 'user': bot, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
+                                <a href="{{ path('TopEditsResult', { 'project': project.domain, 'username': bot, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
                             {% endif %}
                             &middot;
                             {% if enabled('ec') %}
-                                <a href="{{ path('ec', { 'project': project.domain, 'user': bot }) }}">{{ msg('tool-ec') }}</a>
+                                <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': bot }) }}">{{ msg('tool-ec') }}</a>
                             {% endif %}
                         </td>
                         <td class="sort-entry--edits" data-value="{{ botData.count }}">{{ botData.count }}</td>

--- a/app/Resources/views/articleInfo/textshares.html.twig
+++ b/app/Resources/views/articleInfo/textshares.html.twig
@@ -14,9 +14,9 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('articleinfo') }}">
+                <a class="back-to-search" href="{{ path('ArticleInfoResult', {project: project.domain, article:page.title}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('back') }}
+                    {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.pageLink(page) }}
                 <small>
@@ -26,6 +26,8 @@
             </div>
         </header>
         <div class="panel-body xt-panel-body">
+            {{ wiki.pageLinks(page) }}
+
             <section class="panel panel-default clearfix">
                 <header class="panel-heading col-lg-12">
                     <h4>
@@ -74,11 +76,11 @@
                     </td>
                     <td>
                         {% if enabled('topedits') %}
-                            <a href="{{ path('topedits', { 'project': project.domain, 'username': username, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
+                            <a href="{{ path('TopEditsResult', { 'project': project.domain, 'username': username, 'namespace': page.namespace, 'article': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
                         {% endif %}
                         &middot;
                         {% if enabled('ec') %}
-                            <a href="{{ path('ec', { 'project': project.domain, 'username': username }) }}">{{ msg('tool-ec') }}</a>
+                            <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': username }) }}">{{ msg('tool-ec') }}</a>
                         {% endif %}
                     </td>
                     <td class="sort-entry--characters" data-value="{{ values.count }}">
@@ -109,9 +111,18 @@
             </tr></td>
         {% endif %}
     </table>
+
+    {##
+     # Set the size of the chart to be relative to the number of tools.
+     # Otherwise it may get too big and hog up the real estate.
+     # 37 is the heigh of one row.
+     ##}
+    {% set maxHeight = min(400, (textshares.list|length + 2) * 37) %}
+    {% set height = max(150, maxHeight) %}
     <div class="chart-wrapper textshares-chart-wrapper toggle-table--chart">
-        <canvas id="textshares_chart" width="400" height="400"></canvas>
+        <canvas id="textshares_chart" width="{{ height }}" height="{{ height }}"></canvas>
     </div>
+
     {% set colors = [] %}
     {% for i in 0..(textshares.list|length) %}
         {% set colors = colors|merge([chartColor(i)]) %}

--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -9,7 +9,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>
@@ -186,7 +186,7 @@
                 <td>{{ msg('auto-edits') }}</td>
                 <td>
                     {% if enabled('autoedits') %}
-                        <a href="{{ path('autoedits', {project:project.domain, username:user.username, namespace:'all'}) }}">{{ ec.countAutomatedEdits|num_format }}</a>
+                        <a href="{{ path('AutoEditsResult', {project:project.domain, username:user.username, namespace:'all'}) }}">{{ ec.countAutomatedEdits|num_format }}</a>
                     {% else %}
                         {{ ec.countAutomatedEdits }}
                     {% endif %}
@@ -200,7 +200,7 @@
                 <td>{{ msg('edits-with-summaries') }}</td>
                 <td>
                     {% if enabled('es') %}
-                        <a href="{{ path('es', {project:project.domain, username:user.username, namespace:'all'}) }}">{{ ec.countRevisionsWithComments|num_format }}</a>
+                        <a href="{{ path('EditSummaryResult', {project:project.domain, username:user.username, namespace:'all'}) }}">{{ ec.countRevisionsWithComments|num_format }}</a>
                     {% else %}
                         {{ ec.countRevisionsWithComments|num_format }}
                     {% endif %}
@@ -398,12 +398,12 @@
                             <span title="{{ msg('selected') }}">&#9658;</span>
                         {% endif %}
                         {# use project.domain instead of title due to limited space available in the interface #}
-                        {{- wiki.pageLinkRaw('Special:Contributions/'~user.username, topProj.project, topProj.project.domain) -}}
-                    </td>
+                        <a href="{{ path('EditCounterResult', {project:topProj.project.domain, username:user.username}) }}">
+                            {{- topProj.project.domain -}}
+                        </a>{#-
+                    -#}</td>
                     <td>
-                        <a href="{{ path('TopEditsResults', {project:topProj.project.domain, username:user.username, namespace:'all'}) }}">
-                            {{ topProj.total|num_format }}
-                        </a>
+                        {{- wiki.pageLinkRaw('Special:Contributions/'~user.username, topProj.project, topProj.total|num_format) -}}
                     </td>
                 </tr>
             {% endfor %}

--- a/app/Resources/views/editCounter/general_stats.wikitext.twig
+++ b/app/Resources/views/editCounter/general_stats.wikitext.twig
@@ -216,7 +216,7 @@
 | {% if topProj.project.databaseName == project.databaseName %}&#9658;{% endif %}
 {# use project.domain instead of title due to limited space available in the interface #}
 [{{ wiki.pageUrlRaw('Special:Contributions/'~user.username, topProj.project) }} {{ topProj.project.domain }}]
-| [{{ url('TopEditsResults', {project:topProj.project.domain, username:user.username, namespace:'all'}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ topProj.total }}}}]
+| [{{ url('TopEditsResult', {project:topProj.project.domain, username:user.username, namespace:'all'}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ topProj.total }}}}]
 {% endspaceless %}
 
 |-

--- a/app/Resources/views/editCounter/latest_global.html.twig
+++ b/app/Resources/views/editCounter/latest_global.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>
@@ -57,7 +57,7 @@
                     &middot;
                     {{ wiki.userLogLink(user, edit.project) }}
                     &middot;
-                    <a href="{{ path('TopEditsResults', {project:edit.project.databaseName, username:user.username, namespace:edit.page.namespace, article:edit.page.titleWithoutNamespace}) }}">{{ msg('tool-topedits') }}</a>
+                    <a href="{{ path('TopEditsResult', {project:edit.project.databaseName, username:user.username, namespace:edit.page.namespace, article:edit.page.titleWithoutNamespace}) }}">{{ msg('tool-topedits') }}</a>
                 </td>
                 <td class="sort-entry--page-title display-title" data-value="{{ edit.page.title }}">
                     {{ wiki.pageLink(edit.page, edit.page.displayTitle) }}

--- a/app/Resources/views/editCounter/monthcounts.html.twig
+++ b/app/Resources/views/editCounter/monthcounts.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>

--- a/app/Resources/views/editCounter/namespace_totals.html.twig
+++ b/app/Resources/views/editCounter/namespace_totals.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>
@@ -53,7 +53,7 @@
                         {{ nsName(nsId, project.namespaces) }}
                     </td>
                     <td class="sort-entry--count" data-value="{{ value }}">
-                        <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:nsId}) }}">{{ value|num_format }}</a>
+                        <a href="{{ path('TopEditsResult', {project:project.domain, username:user.username, namespace:nsId}) }}">{{ value|num_format }}</a>
                         ({{ value|percent_format(ec.countLiveRevisions) }})
                     </td>
                 </tr>

--- a/app/Resources/views/editCounter/namespace_totals.wikitext.twig
+++ b/app/Resources/views/editCounter/namespace_totals.wikitext.twig
@@ -19,7 +19,7 @@
 {% set availableNamespaces = availableNamespaces|merge([nsId]) %}
 | {{ loop.index }}
 | {{ nsName(nsId, project.namespaces) }}
-| [{{ url('TopEditsResults', {project:project.domain, username:user.username, namespace:nsId}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ value }}}}] ({{ value|percent_format(ec.countLiveRevisions) }})
+| [{{ url('TopEditsResult', {project:project.domain, username:user.username, namespace:nsId}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ value }}}}] ({{ value|percent_format(ec.countLiveRevisions) }})
 |-
 {% endfor %}
 !

--- a/app/Resources/views/editCounter/result.html.twig
+++ b/app/Resources/views/editCounter/result.html.twig
@@ -97,17 +97,17 @@
         {{ layout.content_block(headerLink, content, downloadLink, 'timecard', true) }}
 
         {% set content %}
-            {{ render(path('TopEditsResults', {
+            {{ render(path('TopEditsResult', {
                 'username': user.username,
                 'project': project.domain,
                 'namespace': 'all'
             })) }}
         {% endset %}
         {% set headerLink %}
-            <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:'all'})}}">{{ msg('top-edited-pages') }}</a>
+            <a href="{{ path('TopEditsResult', {project:project.domain, username:user.username, namespace:'all'})}}">{{ msg('top-edited-pages') }}</a>
         {% endset %}
         {% set downloadLink %}
-            {{ layout.downloadLink('TopEditsResults', {project:project.domain, username:user.username, namespace:'all'}, ['wikitext']) }}
+            {{ layout.downloadLink('TopEditsResult', {project:project.domain, username:user.username, namespace:'all'}, ['wikitext']) }}
         {% endset %}
         {{ layout.content_block(headerLink, content, downloadLink, 'top-edited-pages', true) }}
 

--- a/app/Resources/views/editCounter/result.wikitext.twig
+++ b/app/Resources/views/editCounter/result.wikitext.twig
@@ -1,6 +1,6 @@
 == [[User:{{ user.username }}]] ==
 
-{% set link %}[{{ url('EditCounter', {'username': user.username, 'project': project.domain}) }} {{ msg('xtools-title') }}]{% endset %}
+{% set link %}[{{ url('EditCounterResult', {'username': user.username, 'project': project.domain}) }} {{ msg('xtools-title') }}]{% endset %}
 {{ msg('xtools-advert', [link, date()|date('Y-m-d H:i')]) }}
 {{ render(path('EditCounterGeneralStats', {
     'username': user.username,
@@ -22,7 +22,7 @@
     'username': user.username,
     'project': project.domain,
     'format': 'wikitext'
-})) }}{{ render(path('TopEditsResults', {
+})) }}{{ render(path('TopEditsResult', {
     'username': user.username,
     'project': project.domain,
     'namespace': 'all',

--- a/app/Resources/views/editCounter/rights_changes.html.twig
+++ b/app/Resources/views/editCounter/rights_changes.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>

--- a/app/Resources/views/editCounter/timecard.html.twig
+++ b/app/Resources/views/editCounter/timecard.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>

--- a/app/Resources/views/editCounter/yearcounts.html.twig
+++ b/app/Resources/views/editCounter/yearcounts.html.twig
@@ -7,7 +7,7 @@
     <div class="panel panel-primary">
         <header class="panel-heading">
             <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('ec', {project: project.domain, username:user.username}) }}">
+                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
                     <span class="glyphicon glyphicon-chevron-left"></span>
                     {{ msg('see-full-statistics') }}
                 </a>

--- a/app/Resources/views/macros/wiki.html.twig
+++ b/app/Resources/views/macros/wiki.html.twig
@@ -277,3 +277,20 @@
         {% endif %}
     </p>
 {% endspaceless %}{% endmacro %}
+
+{% macro pageLinks(page, pageviewsDateParams = {}) %}{% spaceless %}
+    {% import _self as wiki %}
+    <p class="text-center xt-heading-subtitle">
+        {{ wiki.pageHistLink(page) }}
+        &middot;
+        {{ wiki.pageLogLink(page) }}
+        {% if isWMFLabs() %}
+            &middot;
+            {{ wiki.pageviewsLinks(page, pageviewsDateParams) }}
+            {% if page.wikidataId is defined %}
+                &middot;
+                {{ wiki.extLink('https://tools.wmflabs.org/reasonator/?q=' ~ page.wikidataId, 'Resonator (Wikidata)') }}
+            {% endif %}
+        {% endif %}
+    </p>
+{% endspaceless %}{% endmacro %}

--- a/app/Resources/views/pages/result.html.twig
+++ b/app/Resources/views/pages/result.html.twig
@@ -259,11 +259,11 @@
                                     {{ wiki.pageHistLinkRaw(pagename, project) }}
                                     {% if enabled('articleinfo') %}
                                         &middot;
-                                        <a href="{{ path('articleinfo', { 'project': project.domain, 'article': pagename }) }}">{{ msg('tool-articleinfo') }}</a>
+                                        <a href="{{ path('ArticleInfoResult', { 'project': project.domain, 'article': pagename }) }}">{{ msg('tool-articleinfo') }}</a>
                                     {% endif %}
                                     {% if enabled('topedits') %}
                                         &middot;
-                                        <a href="{{ path('topedits', { 'project': project.domain, 'username': user.username, 'namespace': pages.namespace, 'page': page.page_title }) }}">{{ msg('tool-topedits') }}</a>
+                                        <a href="{{ path('TopEditsResult', { 'project': project.domain, 'username': user.username, 'namespace': pages.namespace, 'page': page.page_title }) }}">{{ msg('tool-topedits') }}</a>
                                     {% endif %}
                                     {% if isWMFLabs() %}
                                         &middot;
@@ -279,7 +279,7 @@
                         <tr class="show-more-row">
                             <td></td>
                             <td colspan={{ columns|length + 1 }}>
-                                <a href="{{ path('pages', { 'project': project.domain, 'username': user.username, 'namespace': ns, 'redirects': pages.redirects }) }}">
+                                <a href="{{ path('PagesResult', { 'project': project.domain, 'username': user.username, 'namespace': ns, 'redirects': pages.redirects }) }}">
                                     {{ (pages.counts[ns].count - maxRows)|number_format }} {{ msg('num-others', [pages.counts[ns].count - maxRows]) }}
                                 </a>
                             </td>
@@ -299,7 +299,7 @@
                     <ul class="pagination xt-pagination">
                         <li{% if not(hasPrev) %} class="disabled"{% endif %}>
                             {% if hasPrev %}
-                                <a href="{{ path('pages', pathVars|merge({'offset': pages.offset - 1})) }}" aria-label="Previous">
+                                <a href="{{ path('PagesResult', pathVars|merge({'offset': pages.offset - 1})) }}" aria-label="Previous">
                             {% endif %}
                             <span aria-hidden="true">&laquo;</span>
                             {% if hasPrev %}</a>{% endif %}
@@ -307,14 +307,14 @@
                         {% for page in 1..numPages %}
                             {% set active = pages.offset == loop.index0 %}
                             <li{% if active %} class="active"{% endif %}>
-                                <a href="{{ path('pages', pathVars|merge({'offset': loop.index0})) }}">
+                                <a href="{{ path('PagesResult', pathVars|merge({'offset': loop.index0})) }}">
                                     {{ page }} {% if active %}<span class="sr-only">(current)</span>{% endif %}
                                 </a>
                             </li>
                         {% endfor %}
                         <li{% if not(hasNext) %} class="disabled"{% endif %}>
                             {% if hasNext %}
-                                <a href="{{ path('pages', pathVars|merge({'offset': pages.offset + 1})) }}" aria-label="Next">
+                                <a href="{{ path('PagesResult', pathVars|merge({'offset': pages.offset + 1})) }}" aria-label="Next">
                             {% endif %}
                             <span aria-hidden="true">&raquo;</span>
                             {% if hasNext %}</a>{% endif %}

--- a/app/Resources/views/pages/result.wikitext.twig
+++ b/app/Resources/views/pages/result.wikitext.twig
@@ -50,13 +50,13 @@
 {% endif %}
 {% endif %}
 {% endif %}
-| [{{ wiki.pageLogUrlRaw(pagename, project) }} {{ msg('log') }}]{% if page.type == 'rev' %} &middot; [{{ wiki.pageHistUrlRaw(pagename, project) }} {{ msg('history') }}]{% if enabled('articleinfo') %} &middot; [{{ url('articleinfo', {'project': project.domain, 'article': pagename}) }} {{ msg('tool-articleinfo') }}]{% endif %}{% if enabled('topedits') %} &middot; [{{ url('topedits', {'project': project.domain, 'username': user.username, 'namespace': pages.namespace, 'page': page.page_title}) }} {{ msg('tool-topedits') }}]{% endif %}{% if isWMFLabs() %} &middot; [https://tools.wmflabs.org/pageviews?project={{ project.domain }}&amp;pages={{ pagename|e('url') }} {{ msg('pageviews') }}]{% endif %}{% endif %}
+| [{{ wiki.pageLogUrlRaw(pagename, project) }} {{ msg('log') }}]{% if page.type == 'rev' %} &middot; [{{ wiki.pageHistUrlRaw(pagename, project) }} {{ msg('history') }}]{% if enabled('articleinfo') %} &middot; [{{ url('ArticleInfoResult', {'project': project.domain, 'article': pagename}) }} {{ msg('tool-articleinfo') }}]{% endif %}{% if enabled('topedits') %} &middot; [{{ url('topedits', {'project': project.domain, 'username': user.username, 'namespace': pages.namespace, 'page': page.page_title}) }} {{ msg('tool-topedits') }}]{% endif %}{% if isWMFLabs() %} &middot; [https://tools.wmflabs.org/pageviews?project={{ project.domain }}&amp;pages={{ pagename|e('url') }} {{ msg('pageviews') }}]{% endif %}{% endif %}
 
 {% endfor %}
 {% if pages.counts[ns].count > maxRows and multiNamspace %}
 |-
 |
-| colspan={{ columns|length + 1 }} | [{{ url('pages', {'project': project.domain, 'username': user.username, 'namespace': ns, 'redirects': pages.redirects}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ (pages.counts[ns].count - maxRows) }}}} {{ msg('num-others', [pages.counts[ns].count - maxRows]) }}]
+| colspan={{ columns|length + 1 }} | [{{ url('PagesResult', {'project': project.domain, 'username': user.username, 'namespace': ns, 'redirects': pages.redirects}) }} {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ (pages.counts[ns].count - maxRows) }}}} {{ msg('num-others', [pages.counts[ns].count - maxRows]) }}]
 {% endif %}
 |}
 {% endfor %}

--- a/app/Resources/views/topedits/result_article.html.twig
+++ b/app/Resources/views/topedits/result_article.html.twig
@@ -7,10 +7,6 @@
 <div class="panel panel-primary">
     <header class="panel-heading">
         <div class="text-center xt-heading-top" >
-            <a class="back-to-search" href="{{ path('topedits', {project: project.domain, username:user.username, namespace: te.namespace, article: page}) }}">
-                <span class="glyphicon glyphicon-chevron-left"></span>
-                {{ msg('see-full-statistics') }}
-            </a>
             <a class="back-to-search" href="{{ path('topedits') }}">
                 <span class="glyphicon glyphicon-chevron-left"></span>
                 {{ msg('back') }}

--- a/app/Resources/views/topedits/result_namespace.html.twig
+++ b/app/Resources/views/topedits/result_namespace.html.twig
@@ -8,7 +8,10 @@
     <div class="panel panel-primary">
         {{ layout.userHeading(user, project, xtPage) }}
         <div class="panel-body xt-panel-body" >
-            {{ wiki.userLinks(user, project, xtPage) }}
+            <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
+                <span class="glyphicon glyphicon-chevron-left"></span>
+                {{ msg('see-full-statistics') }}
+            </a>
             <h3 class="text-center">{{ msg('topedits-per-namespace') }}</h3>
 
             {% if project.userHasOptedIn(user) and te.topEdits|length > 2 %}
@@ -86,14 +89,14 @@
                         &middot;
                         <a href="{{ path('ArticleInfoResult', {project:project.domain, article:page.page_title_ns}) }}">{{ msg('tool-articleinfo') }}</a>
                         &middot;
-                        <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:page.page_namespace, article:page.page_title}) }}" >{{ msg('tool-topedits') }}</a>
+                        <a href="{{ path('TopEditsResult', {project:project.domain, username:user.username, namespace:page.page_namespace, article:page.page_title}) }}" >{{ msg('tool-topedits') }}</a>
                     </td>
                 </tr>
                 {% endfor %}
                 {% if pages|length >= 10 and te.topEdits|length > 1 %}
                     <tr>
                         <td colspan={{ showPageAssessment ? 4 : 3 }}>
-                            <a href="{{ path('TopEditsResults', {project:project.domain, username:user.username, namespace:ns, article:''}) }}">
+                            <a href="{{ path('TopEditsResult', {project:project.domain, username:user.username, namespace:ns, article:''}) }}">
                                 {{ msg('more') }}&hellip;
                             </a>
                         </td>

--- a/app/Resources/views/topedits/result_namespace.wikitext.twig
+++ b/app/Resources/views/topedits/result_namespace.wikitext.twig
@@ -2,7 +2,7 @@
 {% if not is_sub_request %}
 == [[User:{{ user.username }}]] ==
 
-{% set link %}[{{ url('TopEditsResults', {'username': user.username, 'project': project.domain, 'namespace': 'all'}) }} {{ msg('xtools-title') }}]{% endset %}
+{% set link %}[{{ url('TopEditsResult', {'username': user.username, 'project': project.domain, 'namespace': 'all'}) }} {{ msg('xtools-title') }}]{% endset %}
 {{ msg('xtools-advert', [link, date()|date('Y-m-d H:i')]) }}
 
 {% endif %}
@@ -28,11 +28,11 @@
 {% if badge is defined %}
 [[File:{{ badge }}|20px]] {{ page.pa_class ? page.pa_class : msg('unknown') }}
 {% endif %}{% endif %}
-| [{% verbatim %}{{{% endverbatim %}fullurl:Special:Log|page={{ page.page_title_ns|replace({' ': '_'}) }}}} {{ msg('log') }}] &middot; [{{ url('ArticleInfoResult', {project:project.domain, article:page.page_title_ns}) }} {{ msg('tool-articleinfo') }}] &middot; [{{ url('TopEditsResults', {project:project.domain, username:user.username, namespace:page.page_namespace, article:page.page_title}) }} {{ msg('tool-topedits') }}]
+| [{% verbatim %}{{{% endverbatim %}fullurl:Special:Log|page={{ page.page_title_ns|replace({' ': '_'}) }}}} {{ msg('log') }}] &middot; [{{ url('ArticleInfoResult', {project:project.domain, article:page.page_title_ns}) }} {{ msg('tool-articleinfo') }}] &middot; [{{ url('TopEditsResult', {project:project.domain, username:user.username, namespace:page.page_namespace, article:page.page_title}) }} {{ msg('tool-topedits') }}]
 {% endfor %}
 {% if pages|length >= 10 and te.topEdits|length > 1 %}
 |-
-! colspan={{ showPageAssessment ? 4 : 3 }} | [{{ url('TopEditsResults', {project:project.domain, username:user.username, namespace:ns, article:''}) }} {{ msg('more') }}&hellip;]
+! colspan={{ showPageAssessment ? 4 : 3 }} | [{{ url('TopEditsResult', {project:project.domain, username:user.username, namespace:ns, article:''}) }} {{ msg('more') }}&hellip;]
 {% endif %}
 |}
 

--- a/src/AppBundle/Controller/TopEditsController.php
+++ b/src/AppBundle/Controller/TopEditsController.php
@@ -49,7 +49,7 @@ class TopEditsController extends XtoolsController
 
         // Redirect if at minimum project and username are provided.
         if (isset($params['project']) && isset($params['username'])) {
-            return $this->redirectToRoute('TopEditsResults', $params);
+            return $this->redirectToRoute('TopEditsResult', $params);
         }
 
         // Convert the given project (or default project) into a Project instance.
@@ -68,8 +68,9 @@ class TopEditsController extends XtoolsController
 
     /**
      * Display the results.
-     * @Route("/topedits/{project}/{username}/{namespace}/{article}", name="TopEditsResults",
-     *     requirements={"article"=".+"})
+     * @Route("/topedits/{project}/{username}/{namespace}/{article}", name="TopEditsResult",
+     *     requirements = {"article" = ".+", "namespace" = "|all|\d+"}
+     * )
      * @param Request $request The HTTP request.
      * @param int $namespace
      * @param string $article
@@ -100,7 +101,7 @@ class TopEditsController extends XtoolsController
      * @param User $user The User.
      * @param Project $project The project.
      * @param integer|string $namespace The namespace ID or 'all'
-     * @return \Symfony\Component\HttpFoundation\Response
+     * @return Response
      * @codeCoverageIgnore
      */
     public function namespaceTopEdits(Request $request, User $user, Project $project, $namespace)

--- a/web/static/css/articleinfo.scss
+++ b/web/static/css/articleinfo.scss
@@ -29,6 +29,12 @@
         margin-right: 50px;
     }
 
+    #textshares_chart {
+        height: auto;
+        width: auto;
+        display: none;
+    }
+
     .chart-title {
         font-weight: bold;
         text-align: center;


### PR DESCRIPTION
Make textshares chart size relative to the table

Make all subrequest pages have 'See full stats' links