### PR TITLE
AutoEdits: avoid showing edits with overlapping tools

### DIFF
--- a/app/Resources/views/autoEdits/result.html.twig
+++ b/app/Resources/views/autoEdits/result.html.twig
@@ -141,9 +141,15 @@
                                 {{ msg('num-tools', [ae.toolCounts|length]) }}
                             </th>
                             <th class="tools--count">
-                                <a href="{{ path('AutoEditsContributionsResult', {project:project.domain, username:user.username, start: ae.start, end: ae.end, namespace: ae.namespace}) }}">
-                                    {{ ae.toolsTotal|num_format }}
-                                </a>
+                                <a href="{{ path('AutoEditsContributionsResult', {project:project.domain, username:user.username, start: ae.start, end: ae.end, namespace: ae.namespace}) }}">{{ ae.toolsTotal|num_format }}</a>
+                                {% spaceless %}
+                                    <span class="glyphicon glyphicon-info-sign tooltipcss tooltipcss--tool-counts" role="dialog" aria-labelledby="auto-edits-tools-desc">
+                                        <div id="auto-edits-tools-desc" class="tooltip-body">
+                                            {% set summaryLink = "<a href='#summary'>" ~ msg('auto-edits-counts-desc-grand-total') ~ "</a>" %}
+                                            {{ msg('auto-edits-counts-desc', [summaryLink]) }}
+                                        </div>
+                                    </span>
+                                {% endspaceless %}
                             </th>
                             <th colspan=2></th>
                         </tfoot>

--- a/app/config/semi_automated.yml
+++ b/app/config/semi_automated.yml
@@ -5,14 +5,20 @@
 #   Tool name:
 #       regex: Regular expression to match against edit summary
 #       tag: Tag name for the tool, if applicable. See [[Special:Tags]] for full list
+#       single_tag: Set to true to look for edits that *only* have this tag. This is used primarily
+#           for rollback, so that you can see true system rollback and not edits by other tools
+#           that use rollback.
 #       link: Wiki link to tool documentation
 #       label: Text to use as the label, defaults to the tool's key. Use this for translations.
 #       revert: If the tool is used *only* to revert edits (and not also issue talk page
-#               notifications, etc.), set this to `true`. If the tool is capable of reverting
-#               edits, set 'revert' to regex that would only account for reverts.
-#               See the 'Twinkle' entry for an example. The revert-only regex is necessary
-#               for ArticleInfo and elsewhere, so as to differentiate edits that added content
-#               from edits that restored content.
+#           notifications, etc.), set this to `true`. If the tool is capable of reverting
+#           edits, set 'revert' to regex that would only account for reverts.
+#           See the 'Twinkle' entry for an example. The revert-only regex is necessary
+#           for ArticleInfo and elsewhere, so as to differentiate edits that added content
+#           from edits that restored content.
+#       contribs: Set to true to include edits with the given tool in non-automated contributions.
+#           For example, we do this for ProveIt, because that tool often includes prose that was
+#           added by the user, and not entirely a semi-automated edit.
 #
 # Either 'regex' or 'tag' are required. In some cases you might want to include both,
 #   say if older versions of the tool did not add tags to the edits.
@@ -27,11 +33,16 @@ parameters:
     global:
         Generic rollback:
             tag: mw-rollback
+            single_tag: true
             regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) edits by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\] \(\[\[User talk:.*?\|talk\]\]\) to last (version|revision) by .*'
             link: Special:MyLanguage/Project:Rollback
             revert: true
         Undo:
             tag: mw-undo
+            single_tag: true
+            tag_excludes:
+                - mw-rollback
+                - huggle
             regex: '^(Undid|Undo|\[\[WP:UNDO\|Undid\]\]) revision \d+ by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\]'
             link: Special:MyLanguage/Project:Undo
             # This is not considered a revert because you can undo
@@ -81,6 +92,10 @@ parameters:
             tag: ContentTranslation
             regex: 'Created by translating the page'
             link: mw:Special:MyLanguage/Content translation
+        ProveIt:
+            tag: ProveIt edit
+            link: commons:Help:Gadget-ProveIt
+            contribs: true
 
     # Per-language lists. This generally only includes native MediaWiki actions.
     ar:
@@ -372,6 +387,9 @@ parameters:
             link: User:Evad37/MoveToDraft
         Content translation:
             link: Wikipedia:Content translation tool
+        ProveIt:
+            regex: 'with \[\[Wikipedia:ProveIt'
+            link: Wikipedia:ProveIt
     ko.wikipedia.org:
         AutoWikiBrowser:
             regex: '위키백과:AWB\|AWB|(Wikipedia|WP|Project):(AWB|AutoWikiBrowser)'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -40,6 +40,8 @@
 	"auto-contribs-desc": "Browse through a user's (semi-)automated contributions.",
 	"auto-contribs-use-tool": "Show only edits using the tool:",
 	"auto-edits": "(Semi-)automated edits",
+	"auto-edits-counts-desc": "Some tool usage overlaps (e.g. rolling back to a revision that is a redirect counts as Rollback and as Redirect), so the total of edits made with each tool may differ from the $1.",
+	"auto-edits-counts-desc-grand-total": "grand total",
 	"auto-edits-request": "Request that a new (semi-)automated tool be added",
 	"auto-edits-request-doc": "Link to the tool's documentation or homepage",
 	"auto-edits-request-examples": "Links to example edits",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -41,6 +41,8 @@
 	"auto-contribs-desc": "Description for section listing (semi-)automated edits made by a user.",
 	"auto-contribs-use-tool": "Label for dropdown that limits results to edits made by the selected (semi-)automated tool. The dropdown is located immediately after the label.",
 	"auto-edits": "(semi-)automated edits with known tools like Huggle",
+	"auto-edits-counts-desc": "In the AutoEdits tool, this message explains how the totals of individual tools (shown in the '(semi-)automated edits' section) may be different from the total shown in the 'Summary' section. $1 is a link to the 'Summary' section with the message 'auto-edits-counts-grant-total' as the link text.",
+	"auto-edits-counts-desc-grand-total": "The text 'grand total'. This is used as the text for the link in the 'auto-edits-counts-desc' message.",
 	"auto-edits-request": "Text of for a link to request that a new (semi-)automated tool be added to XTools.",
 	"auto-edits-request-doc": "Label for field to enter in a link to a (semi-)automated tool's documentation.",
 	"auto-edits-request-examples": "Label for field to enter in links to example edits where the (semi)-automated tool was used.",

--- a/web/static/css/autoedits.scss
+++ b/web/static/css/autoedits.scss
@@ -40,4 +40,14 @@
         display: inline-block;
         width: auto;
     }
+
+    .tooltipcss--tool-counts {
+        cursor: help;
+        position: relative;
+        vertical-align: -1px;
+
+        .tooltip-body {
+            min-width: 300px;
+        }
+    }
 }

--- a/web/static/js/application.js
+++ b/web/static/js/application.js
@@ -674,7 +674,9 @@
 
         /** global: xtBaseUrl */
         $.ajax({
-            url: xtBaseUrl + endpoint + '/' + editOffset + '?htmlonly=yes',
+            url: xtBaseUrl + endpoint + '/' + editOffset +
+                // Make sure to include any URL parameters, such as tool=Huggle (for AutoEdits).
+                '?htmlonly=yes&' + window.location.search.replace(/^\?/, ''),
             timeout: 30000
         }).done(function (data) {
             $('.contributions-container').html(data).show();


### PR DESCRIPTION
Allow to query for some tools but still include them in the contribs
lists (such as ProveIt).

Fix browsing of contribs when there is a URL query string.

Bug: T191133