### PR TITLE
EditCounter: show when user became autoconfirmed

### DIFF
--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -48,16 +48,16 @@
             <tr>
                 <td><a href="#rights-changes">{{ msg('user-groups') }}</a></td>
                 <td>
-                    {% for group in ec.rightsStates.current %}
+                    {% for group in ec.rightsStates.local.current %}
                         {{ ec.rightsNames[group] }}{% if not loop.last %}, {% endif %}
                     {% endfor %}
                 </td>
             </tr>
-            {% if user.globalGroups(project) %}
+            {% if ec.rightsStates.global.current %}
                 <tr>
                     <td>{{ msg('global-user-groups') }}</td>
                     <td>
-                        {% for group in user.globalGroups(project) %}
+                        {% for group in ec.rightsStates.global.current %}
                             {{ ec.rightsNames[group] }}{% if not loop.last %}, {% endif %}
                         {% endfor %}
                     </td>

--- a/app/Resources/views/editCounter/rights_changes.html.twig
+++ b/app/Resources/views/editCounter/rights_changes.html.twig
@@ -35,20 +35,20 @@
                             <tr>
                                 <td>{{ msg(state ~ '-user-groups') }}</td>
                                 <td>
-                                    {% set localList = ec.rightsStates[state] %}
-                                    {% set globalList = ec.globalRightsStates[state] %}
+                                    {% set localList = ec.rightsStates.local[state] %}
+                                    {% set globalList = ec.rightsStates.global[state] %}
                                     {% if localList|merge(globalList)|length  == 0 %}
                                         <em class="text-muted">{{ msg('none') }}</em>
                                     {% else %}
                                         {% for right in localList %}
                                             <span class="rights-change-name">
-                                                <a target="_blank" href="{{ wiki.pageUrlRaw('Special:ListGroupRights', project) }}#{{ right }}">{{ ec.rightsNames[right] }}</a>{#-
+                                                <a target="_blank" href="{{ wiki.pageUrlRaw('Special:ListGroupRights', project) }}#{{ right }}">{{ ec.rightsName(right) }}</a>{#-
                                                 -#}{% if not loop.last or (loop.last and globalList|length > 0) %},{% endif %}
                                             </span>
                                         {% endfor %}
                                         {% for right in globalList %}
                                             <span class="rights-change-name">
-                                                <a target="_blank" href="{{ wiki.pageUrlRaw('Special:GlobalGroupPermissions', project) }}#{{ right }}">{{ ec.rightsNames[right] }}</a>
+                                                <a target="_blank" href="{{ wiki.pageUrlRaw('Special:GlobalGroupPermissions', project) }}#{{ right }}">{{ ec.rightsName(right) }}</a>
                                                 <span class="text-muted">(global)</span>{#-
                                                 -#}{% if not loop.last %},{% endif %}
                                             </span>

--- a/app/Resources/views/editCounter/rights_changes_table.html.twig
+++ b/app/Resources/views/editCounter/rights_changes_table.html.twig
@@ -16,14 +16,18 @@
         {% for timestamp, change in rightsChanges if index < 10 or not(is_sub_request) %}
             <tr>
                 <td class="sort-entry--date" data-value="{{ timestamp }}">
-                    {{ wiki.logLink(change.type == 'local' ? project : metaProject, change.logId, timestamp|trans|date_format) }}
+                    {% if change.logId is not empty %}
+                        {{ wiki.logLink(change.type == 'local' ? project : metaProject, change.logId, timestamp|trans|date_format) }}
+                    {% else %}
+                        {{ timestamp|trans|date_format }}
+                    {% endif %}
                 </td>
                 <td class="sort-entry--rights" data-value="{{ change.added|length + change.removed|length }}">
                     {% for right in change.added %}
-                        <div class="diff-pos">{{ ec.rightsNames[right]|trim }}</div>
+                        <div class="diff-pos">{{ ec.rightsName(right)|trim }}</div>
                     {% endfor %}
                     {% for right in change.removed %}
-                        <div class="diff-neg" dir="ltr">-{{ ec.rightsNames[right]|trim }}</div>
+                        <div class="diff-neg" dir="ltr">-{{ ec.rightsName(right)|trim }}</div>
                     {% endfor %}
                 </td>
                 <td class="sort-entry--admin" data-value="{{ change.admin }}">

--- a/app/Resources/views/editCounter/rights_changes_table.wikitext.twig
+++ b/app/Resources/views/editCounter/rights_changes_table.wikitext.twig
@@ -8,12 +8,12 @@
 | style="white-space: nowrap;" | {% if change.type == 'local' %}[[Special:Redirect/logid/{{ change.logId }}|{{ timestamp|trans|date_format }}]]{% else %}[https://meta.wikimedia.org/wiki/Special:Redirect/logid/{{ change.logId }} {{ timestamp|trans|date_format }}]{% endif %}
 
 | {% for right in change.added %}
-<span style="color:#006400">+{{ ec.rightsNames[right]|trim }}</span>{% if not loop.last %}, {% endif %}
+<span style="color:#006400">+{{ ec.rightsName(right)|trim }}</span>{% if not loop.last %}, {% endif %}
 {% endfor %}{% if change.added|length > 0 and change.removed|length > 0 %}
 
 {% endif %}
 {% for right in change.removed %}
-<span style="color:#8B0000">-{{ ec.rightsNames[right]|trim }}</span>{% if not loop.last %}, {% endif %}
+<span style="color:#8B0000">-{{ ec.rightsName(right)|trim }}</span>{% if not loop.last %}, {% endif %}
 {% endfor %}
 
 | <span class="plainlinks">[{% verbatim %}{{{% endverbatim %}fullurl:User:{{ change.admin }}}} {{ change.admin }}]</span>

--- a/src/Xtools/Repository.php
+++ b/src/Xtools/Repository.php
@@ -68,7 +68,7 @@ abstract class Repository
     }
 
     /**
-     * Is XTools connecting to MMF Labs?
+     * Is XTools connecting to WMF Labs?
      * @return boolean
      * @codeCoverageIgnore
      */

--- a/src/Xtools/SimpleEditCounter.php
+++ b/src/Xtools/SimpleEditCounter.php
@@ -100,7 +100,7 @@ class SimpleEditCounter extends Model
         }
 
         if (!$this->user->isAnon() && !$this->container->getParameter('app.single_wiki')) {
-            $this->data['globalUserGroups'] = $this->user->getGlobalGroups($this->project);
+            $this->data['globalUserGroups'] = $this->user->getGlobalUserRights($this->project);
         }
     }
 

--- a/src/Xtools/User.php
+++ b/src/Xtools/User.php
@@ -102,6 +102,16 @@ class User extends Model
     }
 
     /**
+     * Get a list of this user's global rights.
+     * @param Project $project A project to query; if not provided, the default will be used.
+     * @return string[]
+     */
+    public function getGlobalUserRights(Project $project = null)
+    {
+        return $this->getRepository()->getGlobalUserRights($this->getUsername(), $project);
+    }
+
+    /**
      * Get the user's (system) edit count.
      * @param Project $project
      * @return int
@@ -131,28 +141,6 @@ class User extends Model
     }
 
     /**
-     * Get a list of this user's groups on the given project.
-     * @param Project $project The project.
-     * @return string[]
-     */
-    public function getGroups(Project $project)
-    {
-        $groupsData = $this->getRepository()->getGroups($project, $this->getUsername());
-        $groups = preg_grep('/\*/', $groupsData, PREG_GREP_INVERT);
-        sort($groups);
-        return $groups;
-    }
-
-    /**
-     * Get a list of this user's groups on all projects.
-     * @param Project $project A project to query; if not provided, the default will be used.
-     */
-    public function getGlobalGroups(Project $project = null)
-    {
-        return $this->getRepository()->getGlobalGroups($this->getUsername(), $project);
-    }
-
-    /**
      * Does this user exist on the given project.
      * @param Project $project
      * @return bool
@@ -170,7 +158,7 @@ class User extends Model
      */
     public function isAdmin(Project $project)
     {
-        return (false !== array_search('sysop', $this->getGroups($project)));
+        return (false !== array_search('sysop', $this->getUserRights($project)));
     }
 
     /**

--- a/src/Xtools/UserRights.php
+++ b/src/Xtools/UserRights.php
@@ -22,8 +22,11 @@ class UserRights extends Model
     /** @var string[] Localized names of the rights. */
     protected $rightsNames;
 
-    /** @var string[] Global rights changes, keyed by timestamp then 'added' and 'removed'. */
+    /** @var string[] Global rights changes (log), keyed by timestamp then 'added' and 'removed'. */
     protected $globalRightsChanges;
+
+    /** @var array The current and former rights of the user. */
+    protected $rightsStates = [];
 
     /**
      * Get user rights changes of the given user.
@@ -42,6 +45,20 @@ class UserRights extends Model
 
         $this->rightsChanges = $this->processRightsChanges($logData);
 
+        $acDate = $this->getAutoconfirmedTimestamp();
+        if ($acDate != false) {
+            $this->rightsChanges[$acDate] = [
+                'logId' => null,
+                'admin' => null,
+                'comment' => null,
+                'added' => ['autoconfirmed'],
+                'removed' => [],
+                'automatic' => true,
+                'type' => 'local',
+            ];
+            krsort($this->rightsChanges);
+        }
+
         return $this->rightsChanges;
     }
 
@@ -54,9 +71,9 @@ class UserRights extends Model
     {
         $rightsStates = $this->getRightsStates();
 
-        if (in_array('sysop', $rightsStates['current'])) {
+        if (in_array('sysop', $rightsStates['local']['current'])) {
             return 'current';
-        } elseif (in_array('sysop', $rightsStates['former'])) {
+        } elseif (in_array('sysop', $rightsStates['local']['former'])) {
             return 'former';
         } else {
             return false;
@@ -65,33 +82,73 @@ class UserRights extends Model
 
     /**
      * Get a list of the current and former rights of the user.
-     * @return array With keys 'current' and 'former'.
+     * @return array With keys 'local' and 'global', each with keys 'current' and 'former'.
      */
     public function getRightsStates()
     {
-        static $rightsStates = null;
-        if ($rightsStates !== null) {
-            return $rightsStates;
+        if (count($this->rightsStates) > 0) {
+            return $this->rightsStates;
         }
 
-        $former = [];
+        foreach (['local', 'global'] as $type) {
+            list($currentRights, $rightsChanges) = $this->getCurrentRightsAndChanges($type);
 
-        foreach (array_reverse($this->getRightsChanges()) as $change) {
-            $former = array_diff(
-                array_merge($former, $change['removed']),
-                $change['added']
+            $former = [];
+
+            // We'll keep track of added rights, which we'll later compare with the
+            // current rights to ensure the list of former rights is complete.
+            // This is because sometimes rights were removed but there mysteriously
+            // is no log entry of it.
+            $added = [];
+
+            foreach ($rightsChanges as $change) {
+                $former = array_diff(
+                    array_merge($former, $change['removed']),
+                    $change['added']
+                );
+
+                $added = array_unique(array_merge($added, $change['added']));
+            }
+
+            // Also tag on rights that were previously added but mysteriously
+            // don't have a log entry for when they were removed.
+            $former = array_merge(
+                array_diff($added, $currentRights),
+                $former
             );
+
+            $this->rightsStates[$type] = [
+                'current' => $currentRights,
+                'former' => array_diff(array_unique($former), $currentRights),
+            ];
         }
 
+        return $this->rightsStates;
+    }
+
+    /**
+     * Get a list of the current trights (of given type) and the log.
+     * @param string $type 'local' or 'global'
+     * @return array [string[] current rights, array rights changes].
+     */
+    private function getCurrentRightsAndChanges($type)
+    {
         // Current rights are not fetched from the log because really old
         // log entries contained little or no metadata, and the rights
         // changes may be undetectable.
-        $rightsStates = [
-            'current' => $this->user->getUserRights($this->project),
-            'former' => array_unique($former),
-        ];
+        if ($type === 'local') {
+            $currentRights = $this->user->getUserRights($this->project);
+            $rightsChanges = $this->getRightsChanges();
 
-        return $rightsStates;
+            if (false != $this->getAutoconfirmedTimestamp()) {
+                $currentRights[] = 'autoconfirmed';
+            }
+        } else {
+            $currentRights = $this->user->getGlobalUserRights($this->project);
+            $rightsChanges = $this->getGlobalRightsChanges();
+        }
+
+        return [$currentRights, $rightsChanges];
     }
 
     /**
@@ -100,47 +157,7 @@ class UserRights extends Model
      */
     public function getGlobalRightsStates()
     {
-        $current = [];
-        $former = [];
-
-        foreach (array_reverse($this->getGlobalRightsChanges()) as $change) {
-            $current = array_diff(
-                array_unique(array_merge($current, $change['added'])),
-                $change['removed']
-            );
-            $former = array_diff(
-                array_unique(array_merge($former, $change['removed'])),
-                $change['added']
-            );
-        }
-
-        return [
-            'current' => $current,
-            'former' => $former,
-        ];
-    }
-
-    /**
-     * Get the localized names for the user groups, fetched from on-wiki system messages.
-     * @return string[] Localized names keyed by database value.
-     */
-    public function getRightsNames()
-    {
-        if (isset($this->rightsNames)) {
-            return $this->rightsNames;
-        }
-
-        $rightsStates = $this->getRightsStates();
-        $globalRightsStates = $this->getGlobalRightsStates();
-        $rightsToCheck = array_merge(
-            array_merge($rightsStates['current'], $globalRightsStates['current']),
-            array_merge($rightsStates['former'], $globalRightsStates['former'])
-        );
-
-        $this->rightsNames = $this->getRepository()
-            ->getRightsNames($this->project, $rightsToCheck, $this->i18n->getLang());
-
-        return $this->rightsNames;
+        return $this->getRightsStates['global'];
     }
 
     /**
@@ -161,6 +178,34 @@ class UserRights extends Model
         $this->globalRightsChanges = $this->processRightsChanges($logData);
 
         return $this->globalRightsChanges;
+    }
+
+    /**
+     * Get the localized names for the user groups, fetched from on-wiki system messages.
+     * @return string[] Localized names keyed by database value.
+     */
+    public function getRightsNames()
+    {
+        if (isset($this->rightsNames)) {
+            return $this->rightsNames;
+        }
+
+        $this->rightsNames = $this->getRepository()
+            ->getRightsNames($this->project, $this->i18n->getLang());
+
+        return $this->rightsNames;
+    }
+
+    /**
+     * Get the localized translation for the given user right.
+     * @param string $name The name of the right, such as 'sysop'.
+     * @return string
+     */
+    public function getRightsName($name)
+    {
+        return isset($this->getRightsNames()[$name])
+            ? $this->getRightsNames()[$name]
+            : $name;
     }
 
     /**
@@ -259,5 +304,59 @@ class UserRights extends Model
         }
 
         return $rightsChanges;
+    }
+
+    /**
+     * Get the timestamp of when the user became autoconfirmed.
+     * @return string YYYYMMDDHHMMSS format.
+     */
+    private function getAutoconfirmedTimestamp()
+    {
+        static $acTimestamp = null;
+        if ($acTimestamp !== null) {
+            return $acTimestamp;
+        }
+
+        $thresholds = $this->getRepository()->getAutoconfirmedAgeAndCount($this->project);
+
+        // Happens for non-WMF installations, or if there is no autoconfirmed status.
+        if (null === $thresholds) {
+            return null;
+        }
+
+        $registrationDate = $this->user->getRegistrationDate($this->project);
+
+        // Sometimes for old accounts the registration date is null, in which case
+        // we won't attempt to find out when they were autoconfirmed.
+        if (!is_a($registrationDate, 'DateTime')) {
+            return false;
+        }
+
+        $acDate = $registrationDate->add(DateInterval::createFromDateString(
+            $thresholds['wgAutoConfirmAge'].' seconds'
+        ))->format('YmdHis');
+
+        // First check if they already had 10 edits made as of $acDate
+        $editsByAcDate = $this->getRepository()->getNumEditsByTimestamp(
+            $this->project,
+            $this->user,
+            $acDate
+        );
+
+        // If more than wgAutoConfirmCount, then $acDate is when they became autoconfirmed.
+        if ($editsByAcDate >= $thresholds['wgAutoConfirmCount']) {
+            return $acDate;
+        }
+
+        // Now check when the nth edit was made, where n is wgAutoConfirmCount.
+        // This will be false if they still haven't made 10 edits.
+        $acTimestamp = $this->getRepository()->getNthEditTimestamp(
+            $this->project,
+            $this->user,
+            $acDate,
+            $thresholds['wgAutoConfirmCount']
+        );
+
+        return $acTimestamp;
     }
 }

--- a/tests/Xtools/EditCounterTest.php
+++ b/tests/Xtools/EditCounterTest.php
@@ -665,18 +665,21 @@ class EditCounterTest extends WebTestCase
         $userRepo->expects($this->once())
             ->method('getUserRights')
             ->wilLReturn(['sysop', 'bureaucrat']);
+        $userRepo->expects($this->once())
+            ->method('getGlobalUserRights')
+            ->wilLReturn(['sysop']);
         $this->user->setRepository($userRepo);
 
         // Current rights.
         $this->assertEquals(
             ['sysop', 'bureaucrat'],
-            $this->editCounter->getRightsStates()['current']
+            $this->editCounter->getRightsStates()['local']['current']
         );
 
         // Former rights.
         $this->assertEquals(
-            ['rollbacker', 'templateeditor', 'ipblock-exempt', 'filemover'],
-            $this->editCounter->getRightsStates()['former']
+            ['ipblock-exempt', 'filemover', 'templateeditor', 'rollbacker'],
+            $this->editCounter->getRightsStates()['local']['former']
         );
 
         // Admin status.

--- a/tests/Xtools/UserTest.php
+++ b/tests/Xtools/UserTest.php
@@ -67,7 +67,7 @@ class UserTest extends PHPUnit_Framework_TestCase
     {
         $userRepo = $this->getMock(UserRepository::class);
         $userRepo->expects($this->once())
-            ->method('getGroups')
+            ->method('getUserRights')
             ->willReturn($groups);
         $user = new User($username);
         $user->setRepository($userRepo);


### PR DESCRIPTION
Show user's registration date, if present

Cache user ID via static variable to reduce redundant querying

ArticleInfo: fix one PHP notice thrown in production