### PR TITLE
autoedits - add another script installer

### DIFF
--- a/app/config/semi_automated.yml
+++ b/app/config/semi_automated.yml
@@ -332,8 +332,8 @@ parameters:
             regex: '\[\[w:en:WP:RLR\|You can help!'
             link: en:WP:RLR
         Script Installer:
-            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer'
-            link: User:Equazcion/ScriptInstaller
+            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer|\(\[\[User:Enterprisey\/script-installer\|script-installer\]\]\)'
+            link: User:Enterprisey/script-installer
         findargdups:
             regex: '\[\[:en:User:Frietjes\/findargdups'
             link: User:Frietjes/findargdups


### PR DESCRIPTION
Add a regex for https://en.wikipedia.org/wiki/User:Enterprisey/script-installer to the regex for Equazcion's script installer, change the link from Equazcion's page to Enterprisey's because Equazcion hasn't edited in over 2 years. This solves https://phabricator.wikimedia.org/T212927