### PR TITLE
Hard-code fallback for ckb number formatting

### DIFF
--- a/app/Resources/views/articleInfo/result.html.twig
+++ b/app/Resources/views/articleInfo/result.html.twig
@@ -79,7 +79,7 @@
                     <tr>
                         <td>ID</td>
                         <td>
-                            {{ wiki.pageInfoLink(page, page.id) }}
+                            {{ wiki.pageInfoLink(page, page.id|num_format) }}
                         </td>
                     </tr>
                     {% if page.wikidataId is not empty %}
@@ -486,10 +486,10 @@
                         {% set userMinorPercent = stats.minor|percent_format(stats.all) %}
                         <td class="sort-entry--minor-percentage" data-value="{{ userMinorPercent }}">{{ userMinorPercent }}</td>
                         <td class="sort-entry--first-edit" data-value="{{ stats.firstId }}">
-                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.firstId, project, stats.first|date('Y-m-d H:i')) }}
+                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.firstId, project, stats.first|date_format('Y-m-d H:i')) }}
                         </td>
                         <td class="sort-entry--latest-edit" data-value="{{ stats.lastId }}">
-                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.lastId, project, stats.last|date('Y-m-d H:i')) }}
+                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.lastId, project, stats.last|date_format('Y-m-d H:i')) }}
                         </td>
                         <td class="sort-entry--average-time-bw-edits" data-value="{{ stats.atbe|num_format(1) }}">
                             {{ stats.atbe|num_format(1) }}

--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -184,7 +184,7 @@
         <div class="footer-about">
             <span>
                 {# The release process is documented at https://xtools.readthedocs.io/en/latest/development.html#releases #}
-                &copy; 2008-2019
+                &copy; {{ 2008|num_format }}-{{ 2019|num_format }}
                 &middot;
                 <a href="https://github.com/x-tools/xtools/releases/tag/{{ version }}" target="_blank" title="Current XTools version">v.{{ version }}</a>
                 (<a href="https://github.com/x-tools/xtools/tree/{{ hash() }}" target="_blank" title="Current code revision">r.{{ shortHash() }}</a>)

--- a/app/Resources/views/editCounter/general_stats.html.twig
+++ b/app/Resources/views/editCounter/general_stats.html.twig
@@ -39,7 +39,7 @@
         {% if not(user.anon) %}
             <tr>
                 <td>{{ msg('user-id') }}</td>
-                <td>{{ user.id(project) }}</td>
+                <td>{{ user.id(project)|num_format }}</td>
             </tr>
             {% set regDate = user.registrationDate(project) %}
             {% if regDate is not empty %}
@@ -481,12 +481,12 @@
         {{
             chart.pie_chart('small_edits',
                 [{
-                    label: '< 20 ' ~ msg('num-bytes', [20]) ~ '*',
+                    label: '< ' ~ 20|num_format ~ ' ' ~ msg('num-bytes', [20]) ~ '*',
                     value: ec.countSmallEdits,
                     percentage: ((ec.countSmallEdits / ec.countLast5000) * 100)
                 },
                 {
-                    label: '≥ 20 ' ~ msg('num-bytes', [20]) ~ '*',
+                    label: '≥ ' ~ 20|num_format ~ ' ' ~ msg('num-bytes', [20]) ~ '*',
                     value: ec.countLast5000 - ec.countSmallEdits,
                     percentage: 100 - ((ec.countSmallEdits / ec.countLast5000) * 100)
                 }]
@@ -495,12 +495,12 @@
         {{
             chart.pie_chart('large_edits',
                 [{
-                    label: '< 1000 ' ~ msg('num-bytes', [1000]) ~ '*',
+                    label: '< ' ~ 1000|num_format ~ ' ' ~ msg('num-bytes', [1000]) ~ '*',
                     value: ec.countLast5000 - ec.countLargeEdits,
                     percentage: 100 - ((ec.countLargeEdits / ec.countLast5000) * 100)
                 },
                 {
-                    label: '≥ 1000 ' ~ msg('num-bytes', [1000]) ~ '*',
+                    label: '≥ ' ~ 1000|num_format ~ ' ' ~ msg('num-bytes', [1000]) ~ '*',
                     value: ec.countLargeEdits,
                     percentage: ((ec.countLargeEdits / ec.countLast5000) * 100)
                 }]

--- a/app/Resources/views/editCounter/latest_global.html.twig
+++ b/app/Resources/views/editCounter/latest_global.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
+                <small> &bull; {{ project.domain }} </small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">

--- a/app/Resources/views/editCounter/monthcounts.html.twig
+++ b/app/Resources/views/editCounter/monthcounts.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
+                <small> &bull; {{ project.domain }} </small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">

--- a/app/Resources/views/editCounter/namespace_totals.html.twig
+++ b/app/Resources/views/editCounter/namespace_totals.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
+                <small> &bull; {{ project.domain }} </small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">

--- a/app/Resources/views/editCounter/rights_changes.html.twig
+++ b/app/Resources/views/editCounter/rights_changes.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small>&bull; {{ project.title }}</small>
+                <small>&bull; {{ project.domain }}</small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">

--- a/app/Resources/views/editCounter/timecard.html.twig
+++ b/app/Resources/views/editCounter/timecard.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
+                <small> &bull; {{ project.domain }} </small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">
@@ -51,7 +51,7 @@
             <th></th>
             {% for period in 0..11 %}
                 <th>
-                    <time>{{ period * 2 }}:00</time>
+                    <time>{{ (period * 2 ~ ':' ~ 00)|date_format('HH:mm') }}</time>
                 </th>
             {% endfor %}
         </thead>
@@ -146,7 +146,7 @@
                         max: 23,
                         stepSize: 2,
                         reverse: i18nRTL,
-                        callback: function(value, index, values) {
+                        callback: function(value) {
                             if (value % 2 === 0) {
                                 return value + ":00";
                             }

--- a/app/Resources/views/editCounter/yearcounts.html.twig
+++ b/app/Resources/views/editCounter/yearcounts.html.twig
@@ -13,7 +13,7 @@
                     {{ msg('see-full-statistics') }}
                 </a>
                 {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
+                <small> &bull; {{ project.domain }} </small>
             </div>
         </header>
         <div class="panel-body xt-panel-body">

--- a/src/AppBundle/Helper/I18nHelper.php
+++ b/src/AppBundle/Helper/I18nHelper.php
@@ -235,7 +235,7 @@ class I18nHelper
     public function numberFormat($number, $decimals = 0): string
     {
         if (!isset($this->numFormatter)) {
-            $lang = $this->getIntuition()->getLang();
+            $lang = $this->getNumberFormatterLang();
             $this->numFormatter = new NumberFormatter($lang, NumberFormatter::DECIMAL);
         }
 
@@ -254,7 +254,7 @@ class I18nHelper
     public function percentFormat($numerator, ?int $denominator = null, int $precision = 1): string
     {
         if (!isset($this->percentFormatter)) {
-            $lang = $this->getIntuition()->getLang();
+            $lang = $this->getNumberFormatterLang();
             $this->percentFormatter = new NumberFormatter($lang, NumberFormatter::PERCENT);
         }
 
@@ -284,7 +284,7 @@ class I18nHelper
     {
         if (!isset($this->dateFormatter)) {
             $this->dateFormatter = new IntlDateFormatter(
-                $this->getIntuition()->getLang(),
+                $this->getNumberFormatterLang(),
                 IntlDateFormatter::SHORT,
                 IntlDateFormatter::SHORT
             );
@@ -302,6 +302,17 @@ class I18nHelper
     }
 
     /********************* PRIVATE MEHTODS *********************/
+
+    /**
+     * TODO: Remove this when the fallbacks start working on their own. Production for some reason
+     *   doesn't seem to know about ckb, though it has the same version of PHP and ext-intl as my local...
+     * @see T213503
+     * @return string
+     */
+    private function getNumberFormatterLang(): string
+    {
+        return 'ckb' === $this->getIntuition()->getLang() ? 'ar' : $this->getIntuition()->getLang();
+    }
 
     /**
      * Determine the interface language, either from the current request or session.


### PR DESCRIPTION
The fallback works on its on my local, but for some reason prod doesn't
agree, even with the same version of PHP and ext-intl. This commit is a
cheap workaround.

Add num_format and date_format to other locations in the app where it
was forgotten.

Bug: T213503