### PR TITLE
AdminStats: cute little icons for user groups, not ambiguous abbrevs

### DIFF
--- a/config/admin_stats.yml
+++ b/config/admin_stats.yml
@@ -2,7 +2,7 @@
 # and which permissions (columns in the view) should be counted.
 #
 # Format:
-#   group_name: (corresponds to i18n key; message should be singular)
+#   type_name: (corresponds to i18n key; message should be singular in English)
 #       user_group: The user group that most closely resembles the 'group'. See Special:ListGroupRights.
 #       permissions: (tells us what users should be in the group, based on the permissions)
 #           - permission (see Special:ListGroupRights)

--- a/config/config.yml
+++ b/config/config.yml
@@ -12,6 +12,7 @@ imports:
     - { resource: quote.yml }
     - { resource: request_blacklist.yml, ignore_errors: true }
     - { resource: admin_stats.yml }
+    - { resource: user_group_icons.yml }
 
 # Put parameters here that don't need to change on each machine where the app is deployed
 # http://symfony.com/doc/current/best_practices/configuration.html#application-related-configuration

--- a/config/user_group_icons.yml
+++ b/config/user_group_icons.yml
@@ -1,0 +1,10 @@
+parameters:
+    user_group_icons:
+        sysop: https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Mop.svg/20px-Mop.svg.png
+        bureaucrat: https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Human-preferences-desktop.svg/20px-Human-preferences-desktop.svg.png
+        steward: https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Wikimedia_Community_Logo.svg/20px-Wikimedia_Community_Logo.svg.png
+        checkuser: https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Gnome-searchtool.svg/20px-Gnome-searchtool.svg.png
+        oversight: https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Oversight_logo.png/20px-Oversight_logo.png
+        interface-admin: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Pliers_with_yellow_handles_(rotated).svg/20px-Pliers_with_yellow_handles_(rotated).svg.png
+        bot: https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Crystal_Clear_action_run.png/20px-Crystal_Clear_action_run.png
+        global-renamer: https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/Global_renamer-logo.svg/20px-Global_renamer-logo.svg.png

--- a/src/AppBundle/Model/AdminStats.php
+++ b/src/AppBundle/Model/AdminStats.php
@@ -8,8 +8,7 @@ declare(strict_types = 1);
 namespace AppBundle\Model;
 
 /**
- * AdminStats returns information about users with administrative
- * rights on a given wiki.
+ * AdminStats returns information about users with rights defined in admin_stats.yml.
  */
 class AdminStats extends Model
 {
@@ -17,12 +16,7 @@ class AdminStats extends Model
     /** @var string[][] Keyed by user name, values are arrays containing actions and counts. */
     protected $adminStats;
 
-    /**
-     * Keys are user names, values are their abbreviated user groups.
-     * If abbreviations are turned on, this will instead be a string of the abbreviated
-     * user groups, separated by slashes.
-     * @var string[]|string
-     */
+    /** @var string[] Keys are user names, values are their user groups. */
     protected $usersAndGroups;
 
     /** @var int Number of users in the relevant group who made any actions within the time period. */
@@ -31,8 +25,8 @@ class AdminStats extends Model
     /** @var string[] Usernames of users who are in the relevant user group (sysop for admins, etc.). */
     private $usersInGroup = [];
 
-    /** @var string Group that we're getting stats for (admin, patrollers, stewards, etc.). See admin_stats.yml */
-    private $group;
+    /** @var string Type that we're getting stats for (admin, patrollers, stewards, etc.). See admin_stats.yml */
+    private $type;
 
     /** @var string[] Which actions to show ('block', 'protect', etc.) */
     private $actions;
@@ -55,7 +49,7 @@ class AdminStats extends Model
         $this->project = $project;
         $this->start = $start;
         $this->end = $end;
-        $this->group = $group;
+        $this->type = $group;
         $this->actions = $actions;
     }
 
@@ -63,9 +57,9 @@ class AdminStats extends Model
      * Get the group for this AdminStats.
      * @return string
      */
-    public function getGroup(): string
+    public function getType(): string
     {
-        return $this->group;
+        return $this->type;
     }
 
     /**
@@ -80,18 +74,16 @@ class AdminStats extends Model
             return $relevantUserGroup;
         }
 
-        return $relevantUserGroup = $this->getRepository()->getRelevantUserGroup($this->group);
+        return $relevantUserGroup = $this->getRepository()->getRelevantUserGroup($this->type);
     }
 
     /**
      * Get the array of statistics for each qualifying user. This may be called ahead of self::getStats() so certain
      * class-level properties will be supplied (such as self::numUsers(), which is called in the view before iterating
      * over the master array of statistics).
-     * @param bool $abbreviateGroups If set, the 'user-groups' list will be a string with abbreivated user groups names,
-     *   as opposed to an array of full-named user groups.
      * @return string[]
      */
-    public function prepareStats(bool $abbreviateGroups = true): array
+    public function prepareStats(): array
     {
         if (isset($this->adminStats)) {
             return $this->adminStats;
@@ -101,10 +93,10 @@ class AdminStats extends Model
         $startDb = date('Ymd000000', $this->start);
         $endDb = date('Ymd235959', $this->end);
 
-        $stats = $this->getRepository()->getStats($this->project, $startDb, $endDb, $this->group, $this->actions);
+        $stats = $this->getRepository()->getStats($this->project, $startDb, $endDb, $this->type, $this->actions);
 
         // Group by username.
-        $stats = $this->groupStatsByUsername($stats, $abbreviateGroups);
+        $stats = $this->groupStatsByUsername($stats);
 
         // Resort, as for some reason the SQL isn't doing this properly.
         uasort($stats, function ($a, $b) {
@@ -120,69 +112,40 @@ class AdminStats extends Model
 
     /**
      * Get users of the project that are capable of making the relevant actions,
-     * keyed by user name with abbreviations for the user groups as the values.
-     * @param bool $abbreviate If set, the keys of the result with be a string containing
-     *   abbreviated versions of their user groups, such as 'A' instead of administrator,
-     *   'CU' instead of CheckUser, etc. If $abbreviate is false, the keys of the result
-     *   will be an array of the full-named user groups.
+     * keyed by user name, with the user groups as the values.
      * @return string[][]
      */
-    public function getUsersAndGroups(bool $abbreviate = true): array
+    public function getUsersAndGroups(): array
     {
-        if ($this->usersAndGroups) {
+        if (isset($this->usersAndGroups)) {
             return $this->usersAndGroups;
         }
 
         /**
-         * Each user group that is considered capable of making 'admin actions'.
+         * Each user group that is considered capable of making the relevant actions for $this->group.
          * @var string[]
          */
-        $adminGroups = $this->getRepository()->getUserGroups($this->project, $this->group);
+        $groupUserGroups = $this->getRepository()->getUserGroups($this->project, $this->type);
 
-        /** @var array $usersAndGroups Keys are the usernames, values are their user groups. */
-        $usersAndGroups = $this->project->getUsersInGroups($adminGroups);
+        $this->usersAndGroups = $this->project->getUsersInGroups($groupUserGroups);
 
-        if (false === $abbreviate || 0 === count($usersAndGroups)) {
-            return $usersAndGroups;
-        }
-
-        /**
-         * Keys are the database-stored names, values are the abbreviations.
-         * FIXME: i18n this somehow.
-         * @var string[]
-         */
-        $userGroupAbbrMap = [
-            'sysop' => 'A',
-            'bureaucrat' => 'B',
-            'steward' => 'S',
-            'checkuser' => 'CU',
-            'oversight' => 'OS',
-            'interface-admin' => 'IA',
-            'bot' => 'Bot',
-            'global-renamer' => 'GR',
-        ];
-
-        foreach ($usersAndGroups as $user => $groups) {
-            $abbrGroups = [];
-
-            // Keep track of actual number of sysops.
-            if (in_array($this->getRelevantUserGroup(), $groups)) {
-                $this->usersInGroup[] = $user;
-            }
-
-            foreach ($groups as $group) {
-                if (isset($userGroupAbbrMap[$group])) {
-                    $abbrGroups[] = $userGroupAbbrMap[$group];
-                }
-            }
-
-            // Make 'A' (admin) come before 'CU' (CheckUser), etc.
-            sort($abbrGroups);
-
-            $this->usersAndGroups[$user] = implode('/', $abbrGroups);
-        }
+        // Populate $this->usersInGroup with users who are in the relevant user group for $this->group.
+        $this->usersInGroup = array_keys(array_filter($this->usersAndGroups, function ($groups) {
+            return in_array($this->getRelevantUserGroup(), $groups);
+        }));
 
         return $this->usersAndGroups;
+    }
+
+    public function getUserGroupIcons(): array
+    {
+        // Quick cache, valid only for the same request.
+        static $userGroupIcons = null;
+        if (null !== $userGroupIcons) {
+            return $userGroupIcons;
+        }
+        $userGroupIcons = $this->getRepository()->getUserGroupIcons();
+        return $userGroupIcons;
     }
 
     /**
@@ -196,14 +159,12 @@ class AdminStats extends Model
 
     /**
      * Get the master array of statistics for each qualifying user.
-     * @param bool $abbreviateGroups If set, the 'user-groups' list will be a string with abbreviated user groups names,
-     *   as opposed to an array of full-named user groups.
      * @return string[]
      */
-    public function getStats(bool $abbreviateGroups = true): array
+    public function getStats(): array
     {
         if (isset($this->adminStats)) {
-            $this->adminStats = $this->prepareStats($abbreviateGroups);
+            $this->adminStats = $this->prepareStats();
         }
         return $this->adminStats;
     }
@@ -223,15 +184,13 @@ class AdminStats extends Model
      * Given the data returned by AdminStatsRepository::getStats, return the stats keyed by user name,
      * adding in a key/value for user groups.
      * @param string[][] $data As retrieved by AdminStatsRepository::getStats
-     * @param bool $abbreviateGroups If set, the 'user-groups' list will be a string with abbreviated user groups names,
-     *   as opposed to an array of full-named user groups.
      * @return string[] Stats keyed by user name.
      * Functionality covered in test for self::getStats().
      * @codeCoverageIgnore
      */
-    private function groupStatsByUsername(array $data, bool $abbreviateGroups = true): array
+    private function groupStatsByUsername(array $data): array
     {
-        $usersAndGroups = $this->getUsersAndGroups($abbreviateGroups);
+        $usersAndGroups = $this->getUsersAndGroups();
         $users = [];
 
         foreach ($data as $datum) {
@@ -249,10 +208,10 @@ class AdminStats extends Model
             if (isset($usersAndGroups[$username])) {
                 $users[$username]['user-groups'] = $usersAndGroups[$username];
             } else {
-                $users[$username]['user-groups'] = $abbreviateGroups ? '' : [];
+                $users[$username]['user-groups'] = [];
             }
 
-            // Keep track of non-admins who made admin actions.
+            // Keep track of users who are not in the relevant user group but made applicable actions.
             if (in_array($username, $this->usersInGroup)) {
                 $this->numWithActions++;
             }

--- a/templates/adminStats/result.html.twig
+++ b/templates/adminStats/result.html.twig
@@ -6,7 +6,7 @@
 <div class="panel panel-primary">
     <header class="panel-heading">
         <div class="text-center xt-heading-top">
-            <a class="back-to-search" href="{{ path('AdminStats', {'group': as.group}) }}">
+            <a class="back-to-search" href="{{ path('AdminStats', {'group': as.type}) }}">
                 <span class="glyphicon glyphicon-chevron-left"></span>
                 {{ msg('back') }}
             </a>
@@ -21,7 +21,7 @@
     </header>
 
     <div class="panel-body xt-panel-body">
-        <h3 class="text-center">{{ msg('tool-' ~ as.group ~ 'stats') }}</h3>
+        <h3 class="text-center">{{ msg('tool-' ~ as.type ~ 'stats') }}</h3>
 
         {% set content %}
             <div class="col-lg-12 stat-list">
@@ -48,13 +48,13 @@
                     {# The value is 0 on wikis that don't have the relevant user group, so this information is not applicable. #}
                     {% if as.numInRelevantUserGroup > 0 %}
                         <tr>
-                            <td>{{ msg('current-' ~ as.group ~ 's') }}</td>
+                            <td>{{ msg('current-' ~ as.type ~ 's') }}</td>
                             <td>
                                 {{ wiki.userGroupLink(as.relevantUserGroup, project, as.numInRelevantUserGroup|num_format) }}
                             </td>
                         </tr>
                         <tr>
-                            <td>{{ msg('non-' ~ as.group ~ 's-with-actions') }}</td>
+                            <td>{{ msg('non-' ~ as.type ~ 's-with-actions') }}</td>
                             <td>{{ as.numWithActionsNotInGroup|num_format }}</td>
                         </tr>
                     {% endif %}
@@ -66,7 +66,7 @@
         <div style="clear:both"></div>
 
         {% set content %}
-            <p>{{ msg(as.group ~ '-stats-notice') }} {{ msg(as.group ~ '-stats-notice2') }}</p>
+            <p>{{ msg(as.type ~ '-stats-notice') }} {{ msg(as.type ~ '-stats-notice2') }}</p>
             <table class="table table-bordered table-hover table-striped top-editors-table table-sticky-header">
                 <thead><tr>
                     <th>#</th>
@@ -95,7 +95,11 @@
                             <td class="sort-entry--username" data-value="{{ username }}">
                                 {{ wiki.userLink(username, project) }}
                             </td>
-                            <td class="sort-entry--user-groups" data-value="{{ user['user-groups'] }}">{{ user['user-groups'] }}</td>
+                            <td class="sort-entry--user-groups" data-value="{{ user['user-groups']|join(',') }}">
+                                {% for group, url in as.userGroupIcons if group in user['user-groups'] %}
+                                    <img src="{{ url }}" title="{{ rightsNames[group]|ucfirst }}" alt="{{ rightsNames[group] }}" />
+                                {% endfor %}
+                            </td>
                             <td>
                                 {% if enabled('EditCounter') %}
                                     <a title="{{ msg('tool-editcounter') }}" href="{{ path('EditCounterResult', {project: project.domain, username: username}) }}" >ec</a>

--- a/tests/AppBundle/Model/AdminStatsTest.php
+++ b/tests/AppBundle/Model/AdminStatsTest.php
@@ -80,20 +80,10 @@ class AdminStatsTest extends TestAdapter
             ->willReturn($this->adminStatsFactory());
         $as->setRepository($this->asRepo);
 
-        // Without abbreviations.
         static::assertEquals(
             [
                 'Bob' => ['sysop', 'checkuser'],
                 'Sarah' => ['epcoordinator'],
-            ],
-            $as->getUsersAndGroups(false)
-        );
-
-        // With abbreviations.
-        static::assertEquals(
-            [
-                'Bob' => 'A/CU',
-                'Sarah' => '',
             ],
             $as->getUsersAndGroups()
         );
@@ -116,11 +106,11 @@ class AdminStatsTest extends TestAdapter
             [
                 'Bob' => array_merge(
                     $this->adminStatsFactory()[0],
-                    ['user-groups' => 'A/CU']
+                    ['user-groups' => ['sysop', 'checkuser']]
                 ),
                 'Sarah' => array_merge(
                     $this->adminStatsFactory()[1], // empty results
-                    ['username' => 'Sarah', 'user-groups' => '']
+                    ['username' => 'Sarah', 'user-groups' => ['epcoordinator']]
                 ),
             ],
             $ret


### PR DESCRIPTION
Rename the 'group' property in AdminStats to 'type', and remove relic
references to 'admin' when the tool now handles any arbitrary user group
and set of rights.

Other code cleanup.