### PR TITLE
AdminStats: Rework admin_stats.yml format; respect installed extensions

### DIFF
--- a/config/admin_stats.yml
+++ b/config/admin_stats.yml
@@ -3,11 +3,13 @@
 #
 # Format:
 #   type_name: (corresponds to i18n key; message should be singular in English)
-#       user_group: The user group that most closely resembles the 'group'. See Special:ListGroupRights.
-#       permissions: (tells us what users should be in the group, based on the permissions)
+#       user_group: (The user group that most closely resembles the 'type'. See Special:ListGroupRights.)
+#       permissions: (Tells us what users should be in the group, based on the permissions)
+#           - extension: (optional; Specify the MediaWiki extension that provides permission). Must be the first entry.
 #           - permission (see Special:ListGroupRights)
-#       action_name: (i18n key; order is the order the columns will appear in the view)
-#           - log_type/log_action (as used in the database, see https://www.mediawiki.org/wiki/Manual:Log_actions)
+#       actions:
+#           action_name: (i18n key; order is the order the columns will appear in the view)
+#               - log_type/log_action (as used in the database, see https://www.mediawiki.org/wiki/Manual:Log_actions)
 #
 # Note that the routes for any new groups must be configured in AdminStatsController.
 #
@@ -30,49 +32,56 @@ parameters:
                 - suppressrevision
                 - undelete
                 - userrights
-            delete:
-                - delete/delete
-            revision-delete:
-                - delete/revision
-            log-delete:
-                - delete/event
-            restore:
-                - delete/restore
-            re-block:
-                - block/block
-                - block/reblock
-            unblock:
-                - block/unblock
-            re-protect:
-                - protect/protect
-                - protect/modify
-                - stable/config
-                - stable/modify
-            unprotect:
-                - project/unprotect
-            rights:
-                - rights/rights
-            merge:
-                - merge/merge
-            import:
-                - import/import
-                - import/upload
-            abusefilter:
-                - abusefilter/modify
-                - abusefilter/create
+            actions:
+                delete:
+                    - delete/delete
+                revision-delete:
+                    - delete/revision
+                log-delete:
+                    - delete/event
+                restore:
+                    - delete/restore
+                re-block:
+                    - block/block
+                    - block/reblock
+                unblock:
+                    - block/unblock
+                re-protect:
+                    - protect/protect
+                    - protect/modify
+                    - stable/config
+                    - stable/modify
+                unprotect:
+                    - project/unprotect
+                rights:
+                    - rights/rights
+                merge:
+                    - merge/merge
+                import:
+                    - import/import
+                    - import/upload
+                abusefilter:
+                    - extension: Abuse Filter
+                    - abusefilter/modify
+                    - abusefilter/create
 
         patroller:
             user_group: patroller
             permissions:
                 - patrol
                 - review
-            patrol:
-                - patrol/patrol
-                - pagetriage-curation/reviewed
-            pc-accept:
-                - review/approve
-            pc-reject:
-                - review/unapprove
+            actions:
+                patrol:
+                    - patrol/patrol
+                page-curation:
+                    - extension: PageTriage
+                    - pagetriage-curation/reviewed
+                pc-accept:
+                    - extension: Flagged Revisions
+                    - review/approve
+                pc-reject:
+                    - extension: Flagged Revisions
+                    - review/unapprove
 
         steward:
             user_group: steward
@@ -82,25 +91,21 @@ parameters:
                 - globalgroupmembership
                 - globalgrouppermissions
                 - userrights-interwiki
-            # TODO: Could be used for non-WMF installations, but otherwise only global-rename applies these days.
-            #rename:
-            #    - renameuser/renameuser
-
-            global-block:
-                - gblblock/gblock
-                - gblblock/modify
-
-            global-unblock:
-                - gblblock/gunblock
-
-            global-rename:
-                - gblrename/rename
-
-            global-rights:
-                - gblrights/usergroups
-                - gblrights/groupprms
-
-            wiki-set-change:
-                - gblrights/setchange
-                - gblrights/setnewtype
-                - gblrights/setrename
+            actions:
+                # TODO: Could be used for non-WMF installations, but otherwise only global-rename applies these days.
+                #rename:
+                #    - renameuser/renameuser
+                global-block:
+                    - gblblock/gblock
+                    - gblblock/modify
+                global-unblock:
+                    - gblblock/gunblock
+                global-rename:
+                    - gblrename/rename
+                global-rights:
+                    - gblrights/usergroups
+                    - gblrights/groupprms
+                wiki-set-change:
+                    - gblrights/setchange
+                    - gblrights/setnewtype
+                    - gblrights/setrename

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -307,6 +307,7 @@
 	"patrols-desc": "$2 {{PLURAL:$1|article|articles}} patrolled",
 	"pc-accept": "Pending change accept",
 	"pc-reject": "Pending change reject",
+	"page-curation": "Page curation",
 	"percent-of-edit-count": "% of edit count",
 	"percent-of-tools": "% of tools",
 	"percentage": "Percentage",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -278,6 +278,7 @@
 	"original-size": "Label for the original size of a page.",
 	"other": "The word 'other', used for general purpose.\n{{Identical|Other}}",
 	"others": "Label in chart for remaining data.\n{{Identical|Other}}",
+	"page-curation": "Name of the Page Curation extension. See {{msg-mw|pagetriage-pagecuration}} for possible translations.",
 	"page-size": "Label for the size of a page.\n{{Identical|Page size}}",
 	"page-title": "Label for the title of a page, or a page title form field.\n{{Identical|Page title}}",
 	"page-watchers": "Wiki page watchers. This message should be short.",

--- a/src/AppBundle/Controller/AdminStatsController.php
+++ b/src/AppBundle/Controller/AdminStatsController.php
@@ -55,7 +55,9 @@ class AdminStatsController extends XtoolsController
             return $this->redirect($url);
         }
 
-        $actionsConfig = $this->container->getParameter('admin_stats');
+        $adminStatsRepo = new AdminStatsRepository();
+        $adminStatsRepo->setContainer($this->container);
+        $actionsConfig = $adminStatsRepo->getConfig($this->project);
         $group = $this->params['group'];
         $xtPage = lcfirst($group).'Stats';
 
@@ -118,10 +120,7 @@ class AdminStatsController extends XtoolsController
     private function getActionNames(string $group): array
     {
         $actionsConfig = $this->container->getParameter('admin_stats');
-        unset($actionsConfig[$group]['permissions']);
-        unset($actionsConfig[$group]['user_group']);
-        $actions = array_keys($actionsConfig[$group]);
-        return $actions;
+        return array_keys($actionsConfig[$group]['actions']);
     }
 
     /**

--- a/src/AppBundle/Model/AdminStats.php
+++ b/src/AppBundle/Model/AdminStats.php
@@ -37,14 +37,14 @@ class AdminStats extends Model
      * @param int $start as UTC timestamp.
      * @param int $end as UTC timestamp.
      * @param string $group Which user group to get stats for. Refer to admin_stats.yml for possible values.
-     * @param string[]|null $actions Which actions to query for ('block', 'protect', etc.). Null for all actions.
+     * @param string[] $actions Which actions to query for ('block', 'protect', etc.). Null for all actions.
      */
     public function __construct(
         Project $project,
         int $start,
         int $end,
-        string $group = 'admin',
-        ?array $actions = null
+        string $group,
+        array $actions
     ) {
         $this->project = $project;
         $this->start = $start;

--- a/src/AppBundle/Model/Project.php
+++ b/src/AppBundle/Model/Project.php
@@ -232,6 +232,21 @@ class Project extends Model
     }
 
     /**
+     * List of extensions that are installed on the wiki.
+     * @return string[]
+     */
+    public function getInstalledExtensions(): array
+    {
+        // Quick cache, valid only for the same request.
+        static $installedExtensions = null;
+        if (is_array($installedExtensions)) {
+            return $installedExtensions;
+        }
+
+        return $installedExtensions = $this->getRepository()->getInstalledExtensions($this);
+    }
+
+    /**
      * Get a list of users who are in one of the given user groups.
      * @param string[] User groups to search for.
      * @return string[] User groups keyed by user name.

--- a/templates/adminStats/index.html.twig
+++ b/templates/adminStats/index.html.twig
@@ -33,9 +33,9 @@
                             {{ msg('all') }}
                         </label>
                     </div>
-                    {% for actionGroup, groupActions in actionsConfig %}
+                    {% for actionGroup, values in actionsConfig %}
                         <div class="multi-select--body action-selector action-selector--{{ actionGroup }}{% if group != actionGroup %} hidden{% endif %}">
-                            {% for action in groupActions|keys if action != 'permissions' and action != 'user_group' %}
+                            {% for action in values.actions|keys %}
                                 <div class="checkbox">
                                     <label>
                                         <input type="checkbox" class="multi-select--option" name="actions[]" value="{{ action }}"{% if action in actions or group != actionGroup %} checked="checked"{% endif %}>

--- a/tests/AppBundle/Model/AdminStatsTest.php
+++ b/tests/AppBundle/Model/AdminStatsTest.php
@@ -51,7 +51,7 @@ class AdminStatsTest extends TestAdapter
         $endUTC = strtotime('2017-03-01');
 
         // Single namespace, with defaults.
-        $as = new AdminStats($this->project, $startUTC, $endUTC);
+        $as = new AdminStats($this->project, $startUTC, $endUTC, 'admin', []);
 
         $this->asRepo->expects(static::once())
             ->method('getStats')
@@ -74,7 +74,7 @@ class AdminStatsTest extends TestAdapter
      */
     public function testAdminsAndGroups(): void
     {
-        $as = new AdminStats($this->project, 0, 0);
+        $as = new AdminStats($this->project, 0, 0, 'admin', []);
         $this->asRepo->expects($this->exactly(0))
             ->method('getStats')
             ->willReturn($this->adminStatsFactory());
@@ -94,7 +94,7 @@ class AdminStatsTest extends TestAdapter
      */
     public function testStats(): void
     {
-        $as = new AdminStats($this->project, 0, 0);
+        $as = new AdminStats($this->project, 0, 0, 'admin', []);
         $this->asRepo->expects($this->once())
             ->method('getStats')
             ->willReturn($this->adminStatsFactory());


### PR DESCRIPTION
You can ensure only applicable actions are shown by specifying which
MediaWiki extensions provide these rights in the YAML config.

Minor tweaks to the SQL query.

Other various code cleanup.