### PR TITLE
Autoedits: multiple additions and updates

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -455,7 +455,8 @@ parameters:
         Reply link:
             regex: '\(\[\[w:en:User:Enterprisey\/reply-link\|reply-link\]\]\)'
             link: User:Enterprisey/reply-link
-            talk_namespaces: true
+            talk_namespaces: true,
+            contribs: true
         Short description:
             regex: '\(\[\[User:Galobtter\/Shortdesc helper\|Shortdesc helper\]\]\)'
             link: User:Galobtter/Shortdesc helper

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -67,7 +67,7 @@ parameters:
             regex: '\|HotCat\]\]|Gadget-Hotcat(?:check)?\.js\|Script|\]\] via HotCat|\[\[WP:HC\|'
             link: Special:MyLanguage/Project:HotCat
         Cat-a-lot:
-            regex: '\[\[Help:Cat-a-lot\|Cat-a-lot\]\]'
+            regex: '\[\[Help:Cat-a-lot\|Cat-a-lot\]\]|\(CatAlot\)|\[\[c:Help:Cat-a-lot\|Cat-a-lot\]\]'
             link: commons:Cat-a-lot
         Global rename:
             regex: 'Automatically moved page while renaming the user'
@@ -354,8 +354,8 @@ parameters:
             regex: '\[\[w:en:WP:RLR\|You can help!'
             link: en:WP:RLR
         Script Installer:
-            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer'
-            link: User:Equazcion/ScriptInstaller
+            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer|\(\[\[User:Enterprisey\/script-installer\|script-installer\]\]\)'
+            link: User:Enterprisey/script-installer
             namespaces: [2]
         findargdups:
             regex: '\[\[:en:User:Frietjes\/findargdups'
@@ -448,6 +448,18 @@ parameters:
         YABBR:
             tag: 'OAuth CID: 860'
             link: User:Enterprisey/YABBR
+            namespaces: [0]
+        effp-helper:
+            regex: '\(\[\[User:Suffusion of Yellow\/effp-helper(\.js)?\|effp-helper\]\]\)'
+            link: User:Suffusion of Yellow/effp-helper
+            namespaces: [0]
+      Reply link:
+            regex: '\(\[\[w:en:User:Enterprisey\/reply-link\|reply-link\]\]\)'
+            link: User:Enterprisey/reply-link
+            talk_namespaces: true
+      Short description:
+            regex: '\(\[\[User:Galobtter\/Shortdesc helper\|Shortdesc helper\]\]\)'
+            link: User:Galobtter/Shortdesc helper
             namespaces: [0]
     ko.wikipedia.org:
         AutoWikiBrowser:

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -67,7 +67,7 @@ parameters:
             regex: '\|HotCat\]\]|Gadget-Hotcat(?:check)?\.js\|Script|\]\] via HotCat|\[\[WP:HC\|'
             link: Special:MyLanguage/Project:HotCat
         Cat-a-lot:
-            regex: '\[\[Help:Cat-a-lot\|Cat-a-lot\]\]|\(CatAlot\)|\[\[c:Help:Cat-a-lot\|Cat-a-lot\]\]'
+            regex: 'Help:Cat-a-lot\|Cat-a-lot\]\]|\(CatAlot\)'
             link: commons:Cat-a-lot
         Global rename:
             regex: 'Automatically moved page while renaming the user'
@@ -452,12 +452,11 @@ parameters:
         effp-helper:
             regex: '\(\[\[User:Suffusion of Yellow\/effp-helper(\.js)?\|effp-helper\]\]\)'
             link: User:Suffusion of Yellow/effp-helper
-            namespaces: [0]
-      Reply link:
+        Reply link:
             regex: '\(\[\[w:en:User:Enterprisey\/reply-link\|reply-link\]\]\)'
             link: User:Enterprisey/reply-link
             talk_namespaces: true
-      Short description:
+        Short description:
             regex: '\(\[\[User:Galobtter\/Shortdesc helper\|Shortdesc helper\]\]\)'
             link: User:Galobtter/Shortdesc helper
             namespaces: [0]


### PR DESCRIPTION
Add effp-helper, reply link, and short description helper. Update regex for CatALot, add another regex for script installer, and change the link to Enterprisey's version. Replaces #253, #251, #250, #249, and #248 (combines the commits, corrects for merge conflict, adds namespace specifications).

Bugs: T217091, T214005, T212925, T213019, and T212927.