### PR TITLE
Add more user icons; show user groups icons for bot and checkuser

### DIFF
--- a/config/admin_stats.yml
+++ b/config/admin_stats.yml
@@ -17,6 +17,7 @@ parameters:
     admin_stats:
         admin:
             user_group: sysop
+            extra_user_groups: ['bot', 'checkuser']
             permissions:
                 - abusefilter-modify
                 - block
@@ -67,6 +68,7 @@ parameters:
 
         patroller:
             user_group: patroller
+            extra_user_groups: ['bot']
             permissions:
                 - patrol
                 - review
@@ -85,6 +87,7 @@ parameters:
 
         steward:
             user_group: steward
+            extra_user_groups: ['bot']
             permissions:
                 - centralauth-rename
                 - globalblock

--- a/config/user_group_icons.yml
+++ b/config/user_group_icons.yml
@@ -1,10 +1,13 @@
 parameters:
     user_group_icons:
-        sysop: https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Mop.svg/18px-Mop.svg.png
-        bureaucrat: https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Human-preferences-desktop.svg/18px-Human-preferences-desktop.svg.png
-        steward: https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Wikimedia_Community_Logo.svg/18px-Wikimedia_Community_Logo.svg.png
-        checkuser: https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Gnome-searchtool.svg/18px-Gnome-searchtool.svg.png
-        oversight: https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Oversight_logo.png/18px-Oversight_logo.png
-        interface-admin: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Pliers_with_yellow_handles_(rotated).svg/18px-Pliers_with_yellow_handles_(rotated).svg.png
+        abusefilter: https://upload.wikimedia.org/wikipedia/commons/thumb/6/64/Wikipedia-Crystal_clear-advancedsetting.png/18px-Wikipedia-Crystal_clear-advancedsetting.png
         bot: https://upload.wikimedia.org/wikipedia/commons/thumb/5/5d/Crystal_Clear_action_run.png/18px-Crystal_Clear_action_run.png
+        bureaucrat: https://upload.wikimedia.org/wikipedia/commons/thumb/a/ac/Human-preferences-desktop.svg/18px-Human-preferences-desktop.svg.png
+        checkuser: https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Gnome-searchtool.svg/18px-Gnome-searchtool.svg.png
+        global-interface-editor: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Pliers_with_yellow_handles_(rotated).svg/18px-Pliers_with_yellow_handles_(rotated).svg.png
         global-renamer: https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/Global_renamer-logo.svg/18px-Global_renamer-logo.svg.png
+        global-sysop: https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/Meta-Wiki_Global_sysop-2000px.png/18px-Meta-Wiki_Global_sysop-2000px.png
+        interface-admin: https://upload.wikimedia.org/wikipedia/commons/thumb/7/7e/Pliers_with_yellow_handles_(rotated).svg/18px-Pliers_with_yellow_handles_(rotated).svg.png
+        oversight: https://upload.wikimedia.org/wikipedia/commons/thumb/0/06/Oversight_logo.png/18px-Oversight_logo.png
+        steward: https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Wikimedia_Community_Logo.svg/18px-Wikimedia_Community_Logo.svg.png
+        sysop: https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Mop.svg/18px-Mop.svg.png

--- a/src/AppBundle/Repository/AdminStatsRepository.php
+++ b/src/AppBundle/Repository/AdminStatsRepository.php
@@ -166,8 +166,14 @@ class AdminStatsRepository extends Repository
         ]))['query'];
 
         $userGroups = [
-            'local' => $this->getUserGroupByLocality($res, $permissions),
-            'global' => $this->getUserGroupByLocality($res, $permissions, true),
+            'local' => array_unique(array_merge(
+                $this->getUserGroupByLocality($res, $permissions),
+                $this->container->getParameter('admin_stats')[$type]['extra_user_groups']
+            )),
+            'global' => array_unique(array_merge(
+                $this->getUserGroupByLocality($res, $permissions, true),
+                $this->container->getParameter('admin_stats')[$type]['extra_user_groups']
+            )),
         ];
 
         // Cache for a week and return.
@@ -176,9 +182,10 @@ class AdminStatsRepository extends Repository
 
     /**
      * Parse user groups API response, returning groups that have any of the given permissions.
-     * @param string[][] $res API response.
+     * @param array[] $res API response.
      * @param string[] $permissions Permissions to look for.
      * @param bool $global Return global user groups instead of local.
+     * @return array[]
      */
     private function getUserGroupByLocality(array $res, array $permissions, bool $global = false): array
     {

--- a/templates/adminStats/result.html.twig
+++ b/templates/adminStats/result.html.twig
@@ -95,7 +95,7 @@
                             <td class="sort-entry--username" data-value="{{ username }}">
                                 {{ wiki.userLink(username, project) }}
                             </td>
-                            <td class="sort-entry--user-groups" data-value="{{ user['user-groups']|join(',') }}">
+                            <td class="sort-entry--user-groups" data-value="{{ user['user-groups']|length }}">
                                 {% for group, url in as.userGroupIcons if group in user['user-groups'] %}
                                     <img class="user-group-icon" src="{{ url }}" title="{{ rightsNames[group]|ucfirst }}" alt="{{ rightsNames[group] }}" />
                                 {% endfor %}


### PR DESCRIPTION
Bot and checkuser don't hold relevant rights to what Admin Stats counts,
but here we add them in with a new 'extra_user_groups' option in
admin_stats.yml.

Bug: T193888
Bug: T213119