### PR TITLE
Base: Use date_format instead of num_format for (c) years in footer

### DIFF
--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -184,7 +184,7 @@
         <div class="footer-about">
             <span>
                 {# The release process is documented at https://xtools.readthedocs.io/en/latest/development.html#releases #}
-                &copy; {{ 2008|num_format }}-{{ 2019|num_format }}
+                &copy; {{ 'jan-2008'|date_format('Y') }}-{{ 'now'|date_format('Y') }}
                 &middot;
                 <a href="https://github.com/x-tools/xtools/releases/tag/{{ version }}" target="_blank" title="Current XTools version">v.{{ version }}</a>
                 (<a href="https://github.com/x-tools/xtools/tree/{{ hash() }}" target="_blank" title="Current code revision">r.{{ shortHash() }}</a>)


### PR DESCRIPTION
num_format causes thousands separators to be inserted (so the footer says
"© 2,008-2,019"). 2008 and 2019 are dates, so date_format makes sense and is
semantically correct.

Just using "2008" will cause PHP to interpret the string as an integer, which
gives incorrect output, so "jan-2008" is used instead. This doesn't cause a
visible change since only the year is displayed.