### PR TITLE
ArticleInfo: add 'n others' slice to top 10 chart

### DIFF
--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -214,13 +214,13 @@ class ArticleInfoController extends XtoolsController
 
         $isSubRequest = $this->request->get('htmlonly')
             || null !== $this->get('request_stack')->getParentRequest();
-
-        $limit = $isSubRequest ? 10 : null;
+        $limit = $isSubRequest ? 10 : ($this->limit ?? 500);
 
         return $this->getFormattedResponse('articleInfo/textshares', [
             'xtPage' => 'ArticleInfo',
             'xtTitle' => $this->page->getTitle(),
             'textshares' => $articleInfo->getTextshares($limit),
+            'limit' => $limit,
             'is_sub_request' => $isSubRequest,
         ]);
     }

--- a/src/AppBundle/Twig/AppExtension.php
+++ b/src/AppBundle/Twig/AppExtension.php
@@ -385,6 +385,7 @@ class AppExtension extends AbstractExtension
             'rgba(141, 211, 199, 1)',
             'rgba(252, 205, 229, 1)',
             'rgba(255, 247, 161, 1)',
+            'rgba(252, 146, 114, 1)',
             'rgba(217, 217, 217, 1)',
         ];
 

--- a/templates/articleInfo/textshares.html.twig
+++ b/templates/articleInfo/textshares.html.twig
@@ -53,7 +53,7 @@
         </p>
     </div>
 {% else %}
-    <table class="table table-bordered table-hover table-striped textshares-table toggle-table">
+    <table class="table table-bordered table-hover table-striped textshares-table pull-left">
         <thead>
         {% for key in ['rank', 'username', 'links', 'characters', 'percentage'] %}
             <th>
@@ -65,6 +65,7 @@
         {% endfor %}
         </thead>
         <tbody>
+            {## Computed #}
             {% set totalPercentage = 0 %}
             {% set totalCount = 0 %}
             {% for username, values in textshares.list %}
@@ -74,8 +75,7 @@
                     <td class="sort-entry--rank" data-value="{{ loop.index }}">{{ loop.index|num_format }}</td>
                     <td class="sort-entry--username" data-value="{{ username }}">
                         <span class="textshares-toggle toggle-table--toggle" data-index="{{ loop.index0 }}" data-key="{{ username }}">
-                            <span class="glyphicon glyphicon-remove"></span>
-                            <span class="color-icon" style="background:{{ chartColor(loop.index0) }}"></span>
+                            <span class="color-icon" style="background:{{ chartColor(min(10, loop.index0)) }}"></span>
                         </span>
                         {{ wiki.userLink(username, project) }}
                     </td>
@@ -97,21 +97,24 @@
                 </tr>
             {% endfor %}
         </tbody>
-        {% if textshares.totalAuthors > 10 and is_sub_request == true %}
+        {% if textshares.others is defined and is_sub_request %}
             <tfoot><tr class="show-more-row">
                 <td></td>
                 <td>
+                    <span class="textshares-toggle toggle-table--toggle" data-index="{{ textshares.list|length }}" data-key="others">
+                        <span class="color-icon" style="background:{{ chartColor(textshares.list|length) }}"></span>
+                    </span>
                     <a href="{{ path('ArticleInfoAuthorshipResult', {project:project.domain, page:page.title})}}">
-                        {{ (textshares.totalAuthors - 10)|num_format }}
-                        {{ msg('num-others', [textshares.totalAuthors - 10]) }}
+                        {{ textshares.others.numEditors|num_format }}
+                        {{ msg('num-others', [textshares.others.numEditors]) }}
                     </a>
                 </td>
                 <td></td>
                 <td>
-                    {{ (textshares.totalCount - totalCount)|num_format }}
+                    {{ textshares.others.count|num_format }}
                 </td>
                 <td>
-                    {{ (100 - totalPercentage)|percent_format }}
+                    {{ textshares.others.percentage|percent_format }}
                 </td>
             </tr></tfoot>
         {% endif %}
@@ -128,20 +131,28 @@
         <canvas id="textshares_chart" width="{{ height }}" height="{{ height }}"></canvas>
     </div>
 
+    {## Get all 11 colours, though we might not use all of them. #}
     {% set colors = [] %}
-    {% for i in 0..(textshares.list|length) %}
+    {% for i in 0..10 %}
         {% set colors = colors|merge([chartColor(i)]) %}
     {% endfor %}
+
+    {% set labels = textshares.list|keys|slice(0, 10) %}
+    {% if textshares.others is defined %}
+        {% set labels = labels|merge([textshares.others.numEditors ~ ' ' ~ msg('num-others', [textshares.others.numEditors])]) %}
+    {% endif %}
+
     <script>
         window.textsharesChart = new Chart($('#textshares_chart'), {
             type: 'pie',
             data: {
-                labels: {{ textshares.list|keys|json_encode()|raw }},
+                labels: {{ labels|json_encode()|raw }},
                 datasets: [{
                     data: [
-                        {% for username, values in textshares.list %}
+                        {% for username, values in textshares.list|slice(0, 10) %}
                             {{ values.percentage }}{% if not loop.last %},{% endif %}
                         {% endfor %}
+                        {% if textshares.others is defined %},{{ textshares.others.percentage }}{% endif %}
                     ],
                     backgroundColor: {{ colors|json_encode()|raw }},
                     borderColor: {{ colors|json_encode()|raw }},

--- a/tests/AppBundle/Model/ArticleInfoTest.php
+++ b/tests/AppBundle/Model/ArticleInfoTest.php
@@ -412,6 +412,7 @@ class ArticleInfoTest extends TestAdapter
      */
     public function testTextshares(): void
     {
+        /** @var ArticleInfoRepository $articleInfoRepo */
         $articleInfoRepo = $this->getMock(ArticleInfoRepository::class);
         $articleInfoRepo->expects($this->once())
             ->method('getTextshares')
@@ -458,6 +459,11 @@ class ArticleInfoTest extends TestAdapter
                 ],
                 'totalAuthors' => 3,
                 'totalCount' => 16,
+                'others' => [
+                    'count' => 3,
+                    'percentage' => 18.7,
+                    'numEditors' => 1,
+                ],
             ],
             $this->articleInfo->getTextshares(2)
         );


### PR DESCRIPTION
Add new 10th color, 11th for the 'n others'

Limit articleinfo-authorship view to 500 results.

Remove toggle table functionality.