### PR TITLE
AudoEdits: optimize namespaces

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -298,6 +298,7 @@ parameters:
         editProtectedHelper:
             regex: 'WP:EPH|EPH'
             link: Project:EPH
+            talk_namespaces: true
         WikiLove:
             regex: 'new WikiLove message'
             link: Project:WikiLove

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -287,6 +287,7 @@ parameters:
         delsort:
             regex: '(Wikipedia:WP):FWDS|User:APerson\/delsort\|delsort.js|User:Enterprisey\/delsort\|assisted'
             link: WP:DELSORT
+            namespaces: [4]
         Ohconfucius script:
             regex: '\[\[(User:Ohconfucius\/.*?|WP:MOSNUMscript)\|script'
             link: Project:MOSNUMscript

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -447,7 +447,7 @@ parameters:
         stubsearch:
             regex: '\[\[User:Danski454\/stubsearch\|a tool'
             link: User:Danski454/stubsearch
-            namespaces: [0, 4]
+            namespaces: [0]
         YABBR:
             tag: 'OAuth CID: 860'
             link: User:Enterprisey/YABBR

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -409,7 +409,6 @@ parameters:
         XFDCloser:
             regex: '\[\[WP:XFDC\|XFDcloser'
             link: User:Evad37/XFDcloser.js
-            namespaces: [0, 4]
         Rater:
             regex: '\[\[User:(Evad37\/rater.js|Kephir\/gadgets\/rater)'
             link: User:Evad37/rater.js

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -63,6 +63,7 @@ parameters:
         IABot:
             tag: 'OAuth CID: 678'
             link: Special:MyLanguage/User:InternetArchiveBot
+            namespaces: [0, 2, 118]
         HotCat:
             regex: '\|HotCat\]\]|Gadget-Hotcat(?:check)?\.js\|Script|\]\] via HotCat|\[\[WP:HC\|'
             link: Special:MyLanguage/Project:HotCat

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -393,6 +393,7 @@ parameters:
         For the Common Good:
             regex: 'WP:FTCG\|FtCG'
             link: Project:FTCG
+            namespaces: [6]
         deOrphan:
             regex: '\[\[User:Technical_13\/Scripts\/OrphanStatus\||\[\[User:DannyS712\/deOrphan\|'
             link: User:DannyS712/deOrphan

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -91,6 +91,7 @@ parameters:
         WikiLove:
             tag: wikilove
             link: mw:Special:MyLanguage/Extension:WikiLove
+            namespaces: [3]
         Content translation:
             tag: contenttranslation
             regex: 'Created by translating the page'


### PR DESCRIPTION
Set namespaces for WikiLove, delsort, editProtectedHelper, For the Common Good, and IABot. Remove current specification from XFDC, and remove the wikipedia namespace from the specification for stubsearch.

Bug: T222323