### PR TITLE
AutoEdits: General cleanup of file

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -115,9 +115,8 @@ parameters:
         Undo:
             regex: 'الرجوع عن التعديل \d+ بواسطة'
     de:
-        Undo:
-            regex: 'Änderung \d+ von \[\[.*?rückgängig gemacht'
-            label: Rückgängig
+        AutoWikiBrowser:
+            regex: 'mit \[\[Project:AWB\|AWB'
         Generic rollback:
             regex: 'Änderungen von \[\[.*?die letzte Version von \[\[.*?zurückgesetzt'
             label: Zurücksetzen
@@ -127,25 +126,26 @@ parameters:
         Redirect:
             regex: 'Weiterleitung nach \[\[.*?erstellt'
             label: Weiterleitung
-        AutoWikiBrowser:
-            regex: 'mit \[\[Project:AWB\|AWB'
-    ko:
         Undo:
-            regex: '판 편집을 되돌림'
-            label: '편집 취소'
+            regex: 'Änderung \d+ von \[\[.*?rückgängig gemacht'
+            label: Rückgängig
+    ko:
         Generic rollback:
             regex: '(의 마지막 판으로 되돌림|의 편집을 전부 되돌림)'
             label: '되돌리기'
         Page move:
             regex: '문서로 이동했습니다'
             label: '문서 이동'
+        Undo:
+            regex: '판 편집을 되돌림'
+            label: '편집 취소'
     pt:
-        Page move:
-            regex: 'moveu \[\[.*?para \[\['
-            label: Movimentos de página
         Content translation:
             regex: 'Criado ao traduzir a página'
             label: Tradução de Conteúdos
+        Page move:
+            regex: 'moveu \[\[.*?para \[\['
+            label: Movimentos de página
         Redirect:
             label: Redirecionamentos
             link: Ajuda:Guia de edição/Redirecionar páginas

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -179,52 +179,7 @@ parameters:
         WPCleaner:
             link: ويكيبيديا:وب_كلينر
             label: وب_كلينر
-    commons.wikimedia.org:
-        AjaxQuickDelete:
-            regex: '^(This category needs discussion|\[\[:.*?\]\] needs discussion|Starting category discussion|Nominating for deletion|\[\[:.*?\]\] has been nominated for deletion|Starting deletion request|Listing \[\[.*?\]\])$|#Autoreport by AjaxQuickDelete|^Updating redirect while processing'
-            link: Special:MyLanguage/Help:Nominate_for_deletion
-        Android Commons:
-            regex: '^Uploaded using Android Commons app$'
-            link: Special:MyLanguage/Commons:Mobile_app
-            namespaces: [6]
-        Commonsist:
-            regex: '^commonist \d\.\d'
-            link: Special:MyLanguage/Commons:Commonist
-            namespaces: [6]
-        Flickr2Commons:
-            regex: 'via \[\[(?:Special:MyLanguage\/)?Commons:Flickr2Commons'
-            link: Special:MyLanguage/Commons:Flickr2Commons
-            namespaces: [6]
-        Geograph2commons:
-            regex: 'Transferred from geograph.co.uk using'
-            link: Special:GoToInterwiki/toollabs:geograph2commons
-            namespaces: [6]
-        POTY:
-            regex: '\[\[Help:(?:Gadget-)EnhancedPOTY.js|POTY App\]\]$'
-            link: Help:Gadget-EnhancedPOTY.js
-            namespaces: [4]
-        QuickDelete:
-            regex: '^(Marking as possible copyvio because|Notification of possible copyright violation for|\[\[.*?\]\] does not have a source|Please send permission for \[\[|\]\] does not have a license)|^(File has no source|Missing permission)$'
-            link: Special:MyLanguage/Help:QuickDelete
-            namespaces: [3, 6]
-        RenameLink:
-            regex: '^\(\[\[Help:RenameLink\|Script'
-            link: Special:MyLanguage/Help:RenameLink
-        RotateLink:
-            regex: '\(\[\[Help:RotateLink\|Script'
-            link: Help:RotateLink
-        SettingsManager:
-            regex: '\[\[MediaWiki:Gadget-SettingsManager.js\|SettingsManager'
-            link: MediaWiki:Gadget-SettingsManager.js
-        UploadWizard:
-            regex: '^User created page with UploadWizard$'
-            link: Special:MyLanguage/Commons:Upload Wizard
-            namespaces: [6]
-        VisualFileChange:
-            regex: 'Using \[\[COM:VFC'
-            tag: VisualFileChange
-            link: Special:MyLanguage/Help:VisualFileChange.js
-    de.wikipedia.org:
+        de.wikipedia.org:
         Generic rollback:
             link: Wikipedia:Zurücksetzen
         Page move:
@@ -516,6 +471,8 @@ parameters:
             regex: 'Desfeita a edição \d+ de \[\['
             link: Ajuda:Guia de edição/Reverter edições#Botão Desfazer
             label: 'Desfazer'
+
+    # Non-wikipedia sites
     www.wikidata.org:
         QuickStatements:
             regex: '#quickstatements'
@@ -523,3 +480,49 @@ parameters:
         RequestDeletion:
             regex: '\[\[MediaWiki talk:Gadget-RequestDeletion\.js\|RD\]\]'
             link: MediaWiki talk:Gadget-RequestDeletion.js
+    commons.wikimedia.org:
+        AjaxQuickDelete:
+            regex: '^(This category needs discussion|\[\[:.*?\]\] needs discussion|Starting category discussion|Nominating for deletion|\[\[:.*?\]\] has been nominated for deletion|Starting deletion request|Listing \[\[.*?\]\])$|#Autoreport by AjaxQuickDelete|^Updating redirect while processing'
+            link: Special:MyLanguage/Help:Nominate_for_deletion
+        Android Commons:
+            regex: '^Uploaded using Android Commons app$'
+            link: Special:MyLanguage/Commons:Mobile_app
+            namespaces: [6]
+        Commonsist:
+            regex: '^commonist \d\.\d'
+            link: Special:MyLanguage/Commons:Commonist
+            namespaces: [6]
+        Flickr2Commons:
+            regex: 'via \[\[(?:Special:MyLanguage\/)?Commons:Flickr2Commons'
+            link: Special:MyLanguage/Commons:Flickr2Commons
+            namespaces: [6]
+        Geograph2commons:
+            regex: 'Transferred from geograph.co.uk using'
+            link: Special:GoToInterwiki/toollabs:geograph2commons
+            namespaces: [6]
+        POTY:
+            regex: '\[\[Help:(?:Gadget-)EnhancedPOTY.js|POTY App\]\]$'
+            link: Help:Gadget-EnhancedPOTY.js
+            namespaces: [4]
+        QuickDelete:
+            regex: '^(Marking as possible copyvio because|Notification of possible copyright violation for|\[\[.*?\]\] does not have a source|Please send permission for \[\[|\]\] does not have a license)|^(File has no source|Missing permission)$'
+            link: Special:MyLanguage/Help:QuickDelete
+            namespaces: [3, 6]
+        RenameLink:
+            regex: '^\(\[\[Help:RenameLink\|Script'
+            link: Special:MyLanguage/Help:RenameLink
+        RotateLink:
+            regex: '\(\[\[Help:RotateLink\|Script'
+            link: Help:RotateLink
+        SettingsManager:
+            regex: '\[\[MediaWiki:Gadget-SettingsManager.js\|SettingsManager'
+            link: MediaWiki:Gadget-SettingsManager.js
+        UploadWizard:
+            regex: '^User created page with UploadWizard$'
+            link: Special:MyLanguage/Commons:Upload Wizard
+            namespaces: [6]
+        VisualFileChange:
+            regex: 'Using \[\[COM:VFC'
+            tag: VisualFileChange
+            link: Special:MyLanguage/Help:VisualFileChange.js
+

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -34,12 +34,63 @@ parameters:
     # Other local values such as link, tag and revert are overriden, not merged into the global value.
     # See 'Huggle' under 'global' and 'en.wikipedia.org' for an example.
     global:
+        AutoWikiBrowser:
+            tag: AWB
+            regex: 'using \[\[(Wikipedia|WP|Project):(AWB|AutoWikiBrowser)'
+            link: Project:AutoWikiBrowser
+        Cat-a-lot:
+            regex: 'Help:Cat-a-lot\|Cat-a-lot\]\]|\(CatAlot\)'
+            link: commons:Cat-a-lot
+        Commons duplicate file:
+            regex: 'COM:Duplicate\|Duplicate'
+            link: c:Commons:Duplicate
+        Commons file rename:
+            regex: 'COM:FR\|File renamed\]\]:'
+            link: c:Special:MyLanguage/Commons:File renaming
+        Content translation:
+            tag: contenttranslation
+            regex: 'Created by translating the page'
+            link: mw:Special:MyLanguage/Content translation
+            contribs: true
+            namespaces: [0, 2, 118]
         Generic rollback:
             tag: mw-rollback
             single_tag: true
             regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) edits by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\] \(\[\[User talk:.*?\|talk\]\]\) to last (version|revision) by .*'
             link: Special:MyLanguage/Project:Rollback
             revert: true
+        Global rename:
+            regex: 'Automatically moved page while renaming the user'
+            link: meta:Special:MyLanguage/Global renamers
+            namespaces: [2, 3]
+        HotCat:
+            regex: '\|HotCat\]\]|Gadget-Hotcat(?:check)?\.js\|Script|\]\] via HotCat|\[\[WP:HC\|'
+            link: Special:MyLanguage/Project:HotCat
+        Huggle:
+            regex: '\(\[\[WP:HG'
+            tag: huggle
+            link: w:en:Wikipedia:Huggle
+        IABot:
+            tag: 'OAuth CID: 678'
+            link: Special:MyLanguage/User:InternetArchiveBot
+            namespaces: [0, 2, 118]
+        Page move:
+            regex: 'moved page \[\[(?!.*?WP:AFCH)|moved \[\[.*?\]\] to \[\['
+            link: mw:Special:MyLanguage/Help:Moving a page
+        Popups:
+            regex: 'Wikipedia:Tools\/Navigation_popups|popups'
+            link: w:en:Project:Popups
+        ProveIt:
+            tag: ProveIt edit
+            link: commons:Help:Gadget-ProveIt
+            contribs: true
+            namespaces: [0, 2, 118]
+        Redirect:
+            tag: mw-new-redirect
+            link: mw:Special:MyLanguage/Help:Redirects
+        reFill:
+            regex: 'User:Zhaofeng Li\/Reflinks|WP:REFILL|en:WP:REFILL|with reFill 2'
+            link: Project:ReFill
         Undo:
             tag: mw-undo
             single_tag: true
@@ -49,66 +100,16 @@ parameters:
             regex: '^(Undid|Undo|\[\[WP:UNDO\|Undid\]\]) revision \d+ by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\]'
             link: Special:MyLanguage/Project:Undo
             # This is not considered a revert because you can undo any arbitrary revision, not just the previous one.
-        Redirect:
-            tag: mw-new-redirect
-            link: mw:Special:MyLanguage/Help:Redirects
-        Huggle:
-            regex: '\(\[\[WP:HG'
-            tag: huggle
-            link: w:en:Wikipedia:Huggle
-        WPCleaner:
-            regex: 'WP:CLEANER|WPCleaner\]\]|\[\[\Wikipedia:DPL|\[\[WP:WCW\]\] project \('
-            tag: WPCleaner
-            link: Special:MyLanguage/Project:WPCleaner
-        IABot:
-            tag: 'OAuth CID: 678'
-            link: Special:MyLanguage/User:InternetArchiveBot
-            namespaces: [0, 2, 118]
-        HotCat:
-            regex: '\|HotCat\]\]|Gadget-Hotcat(?:check)?\.js\|Script|\]\] via HotCat|\[\[WP:HC\|'
-            link: Special:MyLanguage/Project:HotCat
-        Cat-a-lot:
-            regex: 'Help:Cat-a-lot\|Cat-a-lot\]\]|\(CatAlot\)'
-            link: commons:Cat-a-lot
-        Global rename:
-            regex: 'Automatically moved page while renaming the user'
-            link: meta:Special:MyLanguage/Global renamers
-            namespaces: [2, 3]
-        Page move:
-            regex: 'moved page \[\[(?!.*?WP:AFCH)|moved \[\[.*?\]\] to \[\['
-            link: mw:Special:MyLanguage/Help:Moving a page
-        Popups:
-            regex: 'Wikipedia:Tools\/Navigation_popups|popups'
-            link: w:en:Project:Popups
-        Commons file rename:
-            regex: 'COM:FR\|File renamed\]\]:'
-            link: c:Special:MyLanguage/Commons:File renaming
-        Commons duplicate file:
-            regex: 'COM:Duplicate\|Duplicate'
-            link: c:Commons:Duplicate
-        reFill:
-            regex: 'User:Zhaofeng Li\/Reflinks|WP:REFILL|en:WP:REFILL|with reFill 2'
-            link: Project:ReFill
         WikiLove:
             tag: wikilove
             link: mw:Special:MyLanguage/Extension:WikiLove
             namespaces: [3]
-        Content translation:
-            tag: contenttranslation
-            regex: 'Created by translating the page'
-            link: mw:Special:MyLanguage/Content translation
-            contribs: true
-            namespaces: [0, 2, 118]
-        ProveIt:
-            tag: ProveIt edit
-            link: commons:Help:Gadget-ProveIt
-            contribs: true
-            namespaces: [0, 2, 118]
-        AutoWikiBrowser:
-            tag: AWB
-            regex: 'using \[\[(Wikipedia|WP|Project):(AWB|AutoWikiBrowser)'
-            link: Project:AutoWikiBrowser
-
+        WPCleaner:
+            regex: 'WP:CLEANER|WPCleaner\]\]|\[\[\Wikipedia:DPL|\[\[WP:WCW\]\] project \('
+            tag: WPCleaner
+            link: Special:MyLanguage/Project:WPCleaner
+        
+        
     # Per-language lists. This generally only includes native MediaWiki actions.
     ar:
         Undo:

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -240,6 +240,24 @@ parameters:
             regex: \[\[Hilfe:Einfügen-Erweiterung\|
             link: Hilfe:Einfügen-Erweiterung
     en.wikipedia.org:
+        # Global tools
+        Content translation:
+            link: Wikipedia:Content translation tool
+        Huggle:
+            revert: 'Reverted edits by.*?WP:HG'
+        ProveIt:
+            regex: 'with \[\[Wikipedia:ProveIt'
+            link: Wikipedia:ProveIt
+            namespaces: [0, 2, 118]
+        Redirect:
+            regex: '\[\[WP:AES\|←\]\]Redirected page to \[\[.*?\]\]'
+            link: Project:Redirect
+        WikiLove:
+            regex: 'new WikiLove message'
+            link: Project:WikiLove
+            namespaces: [3]
+
+        # Local tools
         Admin actions:
             regex: '^(Protected|Changed protection).*?\[[Ee]dit=|^Removed protection from|^Configured pending changes.*?\[[Aa]uto-accept|^Reset pending changes settings'
             link: Project:Administrators
@@ -289,8 +307,6 @@ parameters:
             regex: '\(using \[\[User:Doug\/closetfd.js'
             link: User:Doug/closetfd.js
             namespaces: [4]
-        Content translation:
-            link: Wikipedia:Content translation tool
         CSD Helper:
             regex: '\(\[\[User:Ale_jrb\/Scripts\|CSDH'
             link: Project:CSDH
@@ -340,8 +356,6 @@ parameters:
         Global replace:
             regex: '\(\[\[c:GR\|GR\]\]\) '
             link: commons:Commons:File renaming/Global replace
-        Huggle: # This gets merged into the global Huggle definition (the revert regex here is enwiki-specific)
-            revert: 'Reverted edits by.*?WP:HG'
         Igloo:
             regex: 'Wikipedia:Igloo'
             link: w:en:Wikipedia:Igloo
@@ -373,17 +387,10 @@ parameters:
             link: Project:Pending changes
             revert: true
             namespaces: [0]
-        ProveIt:
-            regex: 'with \[\[Wikipedia:ProveIt'
-            link: Wikipedia:ProveIt
-            namespaces: [0, 2, 118]
         Rater:
             regex: '\[\[User:(Evad37\/rater.js|Kephir\/gadgets\/rater)'
             link: User:Evad37/rater.js
             talk_namespaces: true
-        Redirect:
-            regex: '\[\[WP:AES\|←\]\]Redirected page to \[\[.*?\]\]'
-            link: Project:Redirect
         Red Link Recovery Live:
             regex: '\[\[w:en:WP:RLR\|You can help!'
             link: en:WP:RLR
@@ -451,10 +458,6 @@ parameters:
         Vada:
             regex: '\(\[\[WP:Vada\]\]\)'
             link: Project:Vada
-        WikiLove:
-            regex: 'new WikiLove message'
-            link: Project:WikiLove
-            namespaces: [3]
         WikiPatroller:
             regex: 'User:Jfmantis\/WikiPatroller'
             link: User:Jfmantis/WikiPatroller

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -239,236 +239,236 @@ parameters:
             regex: \[\[Hilfe:Einfügen-Erweiterung\|
             link: Hilfe:Einfügen-Erweiterung
     en.wikipedia.org:
-        Pending changes revert:
-            regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) \d+ (\[\[Wikipedia:Pending changes\|pending\]\]|pending) edits? (to revision \d+|by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\])'
-            link: Project:Pending changes
-            revert: true
+        Admin actions:
+            regex: '^(Protected|Changed protection).*?\[[Ee]dit=|^Removed protection from|^Configured pending changes.*?\[[Aa]uto-accept|^Reset pending changes settings'
+            link: Project:Administrators
+        Advisor.js:
+            regex: '\(using \[\[(User:Cameltrader#Advisor.js|User:PC-XT\/Advisor)\|Advisor.js'
+            link: WP:ADVISOR
+        AFCH:
+            regex: 'WP:(AFCH|AFCHRW)'
+            link: Project:AFCH
+            namespaces: [0, 2, 4, 5, 118]
+        AFC/R HS:
+            regex: 'Using \[\[User:PhantomTech\/scripts\/AFCRHS\.js|\(\[\[User:Enterprisey\/AFCRHS'
+            link: User:Enterprisey/AFCRHS
+            namespaces: [0, 2]
+        AfD closures:
+            regex: '^\[\[Wikipedia:Articles for deletion\/.*?closed as'
+            link: Project:Articles for deletion
+            namespaces: [0, 4]
+        Archiving script:
+            regex: '\[\[(User:Equazcion\/OneClickArchiver|User:Technical 13\/1CA)\|OneClickArchiver|Removed \d+ threads? to \[\[|Added threads from \[\['
+            link: Project:OneClickArchiver
+        AutoEd:
+            regex: 'using \[\[(Wikipedia|WP):AutoEd\|AutoEd'
+            link: Project:AutoEd
+        autoFormatter:
+            regex: 'using (\[\[:meta:User:TMg\/autoFormatter|autoFormatter)'
+            link: meta:User:TMg/autoFormatter
+        AutoSpell:
+            regex: 'User:Symplectic_Map\/AutoSpell\|Script-assisted'
+            link: User:Symplectic_Map/AutoSpell
             namespaces: [0]
         Bot revert:
             regex: '^Reverting possible (vandalism|test edit).*by.*\(Bot|BOT( EDIT)?\)$|^BOT (- )?(Reverted edits? by|rv)|^vandalism from \[\[.*?\(\d+\) - reverted'
             link: Project:Bots
             revert: true
-        Huggle: # This gets merged into the global Huggle definition (the revert regex here is enwiki-specific)
-            revert: 'Reverted edits by.*?WP:HG'
-        Page curation:
-            regex: 'using \[\[Wikipedia:Page Curation\|Page Curation'
-            link: w:en:Wikipedia:Page_Curation/Help
-            namespaces: [0, 2, 3]
-        Twinkle:
-            regex: '(Wikipedia|WP):(TW|TWINKLE|Twinkle|FRIENDLY)'
-            link: Project:Twinkle
-            revert: '(Reverted to revision|Reverted \d+ edits).*(WP:(TW|TWINKLE|Twinkle)|Wikipedia:Twinkle)'
-        STiki:
-            regex: 'WP:(STiki|STIKI)'
-            link: w:en:Wikipedia:STiki
-            revert: Reverted \d+.*WP:(STiki|STIKI)
-        Igloo:
-            regex: 'Wikipedia:Igloo'
-            link: w:en:Wikipedia:Igloo
-        AFCH:
-            regex: 'WP:(AFCH|AFCHRW)'
-            link: Project:AFCH
-            namespaces: [0, 2, 4, 5, 118]
         Checklinks:
             regex: 'using \[\[w:WP:CHECKLINKS'
             link: Project:CHECKLINKS
-        Dab solver:
-            regex: 'using \[\[(tools:~dispenser\/view\/Dab_solver|WP:DABSOLVER)\|Dab solver|(Disambiguated|Unlinked|Help needed): \[\[|Disambiguated \d+ links|Repaired link.*?\[\[Wikipedia:WikiProject Disambiguation\|please help'
-            link: Project:DABSOLVER
-        Dabfix:
-            regex: 'using \[\[tools:~dispenser\/cgi-bin\/dabfix.py'
-            link: Special:GoToInterwiki/toollabs:dispenser/cgi-bin/dabfix.py
-        Reflinks:
-            regex: '\[\[(tools:~dispenser\/view\/Reflinks|WP:REFLINKS)\|Reflinks'
-            link: Project:REFLINKS
-        WikiPatroller:
-            regex: 'User:Jfmantis\/WikiPatroller'
-            link: User:Jfmantis/WikiPatroller
-            namespaces: [0, 3]
-        delsort:
-            regex: '(Wikipedia:WP):FWDS|User:APerson\/delsort\|delsort.js|User:Enterprisey\/delsort\|assisted'
-            link: WP:DELSORT
-            namespaces: [4]
-        Ohconfucius script:
-            regex: '\[\[(User:Ohconfucius\/.*?|WP:MOSNUMscript)\|script'
-            link: Project:MOSNUMscript
-            namespaces: [0, 2, 118]
-        Archiving script:
-            regex: '\[\[(User:Equazcion\/OneClickArchiver|User:Technical 13\/1CA)\|OneClickArchiver|Removed \d+ threads? to \[\[|Added threads from \[\['
-            link: Project:OneClickArchiver
-        editProtectedHelper:
-            regex: 'WP:EPH|EPH'
-            link: Project:EPH
-            talk_namespaces: true
-        WikiLove:
-            regex: 'new WikiLove message'
-            link: Project:WikiLove
-            namespaces: [3]
-        AutoEd:
-            regex: 'using \[\[(Wikipedia|WP):AutoEd\|AutoEd'
-            link: Project:AutoEd
-        Mike's Wiki Tool:
-            regex: User:MichaelBillington\/MWT\|MWT|Mike's Wiki Tool
-            link: Project:Mike's Wiki Tool
-            namespaces: [0]
-        Global replace:
-            regex: '\(\[\[c:GR\|GR\]\]\) '
-            link: commons:Commons:File renaming/Global replace
-        Admin actions:
-            regex: '^(Protected|Changed protection).*?\[[Ee]dit=|^Removed protection from|^Configured pending changes.*?\[[Aa]uto-accept|^Reset pending changes settings'
-            link: Project:Administrators
-        CSD Helper:
-            regex: '\(\[\[User:Ale_jrb\/Scripts\|CSDH'
-            link: Project:CSDH
-        responseHelper:
-            regex: '\(using \[\[User:MusikAnimal\/responseHelper\|responseHelper'
-            link: User:MusikAnimal/responseHelper
-            namespaces: [4]
-        Advisor.js:
-            regex: '\(using \[\[(User:Cameltrader#Advisor.js|User:PC-XT\/Advisor)\|Advisor.js'
-            link: WP:ADVISOR
-        AfD closures:
-            regex: '^\[\[Wikipedia:Articles for deletion\/.*?closed as'
-            link: Project:Articles for deletion
-            namespaces: [0, 4]
-        Sagittarius:
-            regex: '\(\[\[User:Kephir\/gadgets\/sagittarius\||\(\[\[User:Sam Sailor\/Scripts\/Sagittarius\+\|'
-            link: User:Sam Sailor/Scripts/Sagittarius+
-        Redirect:
-            regex: '\[\[WP:AES\|←\]\]Redirected page to \[\[.*?\]\]'
-            link: Project:Redirect
-        Dashes:
-            regex: 'using a \[\[User:GregU\/dashes.js\|script'
-            link: User:GregU/dashes
-        SPI Helper:
-            regex: '^(Archiving case (to|from)|Adding sockpuppetry (tag|block notice) per) \[\[Wikipedia:Sockpuppet investigations'
-            link: User:Timotheus Canens/spihelper.js
-            namespaces: [2, 3, 4]
-        closetfd.js:
-            regex: '\(using \[\[User:Doug\/closetfd.js'
-            link: User:Doug/closetfd.js
-            namespaces: [4]
-        autoFormatter:
-            regex: 'using (\[\[:meta:User:TMg\/autoFormatter|autoFormatter)'
-            link: meta:User:TMg/autoFormatter
         Citation bot:
             regex: '\[\[WP:UCB\|Assisted by Citation bot'
             link: Project:UCB
-        Red Link Recovery Live:
-            regex: '\[\[w:en:WP:RLR\|You can help!'
-            link: en:WP:RLR
-        Script Installer:
-            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer|\(\[\[User:Enterprisey\/script-installer\|script-installer\]\]\)'
-            link: User:Enterprisey/script-installer
-            namespaces: [2]
-        findargdups:
-            regex: '\[\[:en:User:Frietjes\/findargdups'
-            link: User:Frietjes/findargdups
         closemfd.js:
             regex: '\(using \[\[User:Doug\/closemfd.js'
             link: User:Doug/closemfd.js
             namespaces: [4]
-        DisamAssist:
-            regex: 'using \[\[User:Qwertyytrewqqwerty\/DisamAssist'
-            link: User:Qwertyytrewqqwerty/DisamAssist
-            namespaces: [0, 6, 10, 14, 100, 108]
-        Vada:
-            regex: '\(\[\[WP:Vada\]\]\)'
-            link: Project:Vada
-        stubtagtab.js:
-            regex: 'using \[\[User:MC10\/stubtagtab.js'
-            link: User:MC10/stubtagtab.js
-            namespaces: [0]
-        AutoSpell:
-            regex: 'User:Symplectic_Map\/AutoSpell\|Script-assisted'
-            link: User:Symplectic_Map/AutoSpell
-            namespaces: [0]
-        Draftify:
-            regex: '\(\[\[WP:DFY\|DFY\]\]\)'
-            link: Project:DFY
-            namespaces: [2, 3]
-        AFC/R HS:
-            regex: 'Using \[\[User:PhantomTech\/scripts\/AFCRHS\.js|\(\[\[User:Enterprisey\/AFCRHS'
-            link: User:Enterprisey/AFCRHS
-            namespaces: [0, 2]
-        For the Common Good:
-            regex: 'WP:FTCG\|FtCG'
-            link: Project:FTCG
-            namespaces: [6]
+        closetfd.js:
+            regex: '\(using \[\[User:Doug\/closetfd.js'
+            link: User:Doug/closetfd.js
+            namespaces: [4]
+        Content translation:
+            link: Wikipedia:Content translation tool
+        CSD Helper:
+            regex: '\(\[\[User:Ale_jrb\/Scripts\|CSDH'
+            link: Project:CSDH
+        Dabfix:
+            regex: 'using \[\[tools:~dispenser\/cgi-bin\/dabfix.py'
+            link: Special:GoToInterwiki/toollabs:dispenser/cgi-bin/dabfix.py
+        Dab solver:
+            regex: 'using \[\[(tools:~dispenser\/view\/Dab_solver|WP:DABSOLVER)\|Dab solver|(Disambiguated|Unlinked|Help needed): \[\[|Disambiguated \d+ links|Repaired link.*?\[\[Wikipedia:WikiProject Disambiguation\|please help'
+            link: Project:DABSOLVER
+        Dashes:
+            regex: 'using a \[\[User:GregU\/dashes.js\|script'
+            link: User:GregU/dashes
+        delsort:
+            regex: '(Wikipedia:WP):FWDS|User:APerson\/delsort\|delsort.js|User:Enterprisey\/delsort\|assisted'
+            link: WP:DELSORT
+            namespaces: [4]
         deOrphan:
             regex: '\[\[User:Technical_13\/Scripts\/OrphanStatus\||\[\[User:DannyS712\/deOrphan\|'
             link: User:DannyS712/deOrphan
             namespaces: [0]
-        The Wikipedia Adventure:
-            regex: 'simulated automatically as part of \[\[WP:The Wikipedia Adventure\|'
-            link: Project:TWA
-            namespaces: [2]
-        OABot:
-            tag: 'OAuth CID: 817'
-            link: Project:OABOT
-            namespaces: [0, 2]
-        XFDCloser:
-            regex: '\[\[WP:XFDC\|XFDcloser'
-            link: User:Evad37/XFDcloser.js
-        Rater:
-            regex: '\[\[User:(Evad37\/rater.js|Kephir\/gadgets\/rater)'
-            link: User:Evad37/rater.js
-            talk_namespaces: true
-        revdel:
-            regex: 'using \[\[User:Primefac\/revdel|User:Enterprisey\/cv-revdel\|'
-            link: User:Enterprisey/cv-revdel
+        DisamAssist:
+            regex: 'using \[\[User:Qwertyytrewqqwerty\/DisamAssist'
+            link: User:Qwertyytrewqqwerty/DisamAssist
+            namespaces: [0, 6, 10, 14, 100, 108]
+        Draftify:
+            regex: '\(\[\[WP:DFY\|DFY\]\]\)'
+            link: Project:DFY
+            namespaces: [2, 3]
         draft-sorter:
             regex: '\(draft-sorter\.js\)'
             link: User:Enterprisey/draft-sorter
             namespaces: [119]
-        Xunlink:
-            regex: '\(\[\[User:Evad37\/Xunlink'
-            link: User:Evad37/Xunlink
-            namespaces: [0, 10, 100, 118]
+        editProtectedHelper:
+            regex: 'WP:EPH|EPH'
+            link: Project:EPH
+            talk_namespaces: true
+        effp-helper:
+            regex: '\(\[\[User:Suffusion of Yellow\/effp-helper(\.js)?\|effp-helper\]\]\)'
+            link: User:Suffusion of Yellow/effp-helper
+        findargdups:
+            regex: '\[\[:en:User:Frietjes\/findargdups'
+            link: User:Frietjes/findargdups
+        For the Common Good:
+            regex: 'WP:FTCG\|FtCG'
+            link: Project:FTCG
+            namespaces: [6]
+        Global replace:
+            regex: '\(\[\[c:GR\|GR\]\]\) '
+            link: commons:Commons:File renaming/Global replace
+        Huggle: # This gets merged into the global Huggle definition (the revert regex here is enwiki-specific)
+            revert: 'Reverted edits by.*?WP:HG'
+        Igloo:
+            regex: 'Wikipedia:Igloo'
+            link: w:en:Wikipedia:Igloo
+        JWB:
+            regex: 'via (JWB|\[\[WP:JWB\]\])'
+            link: WP:JWB
+        Mike's Wiki Tool:
+            regex: User:MichaelBillington\/MWT\|MWT|Mike's Wiki Tool
+            link: Project:Mike's Wiki Tool
+            namespaces: [0]
         MoveToDraft:
             regex: '\[\[User:Evad37\/MoveToDraft\.js\|via script'
             link: User:Evad37/MoveToDraft
             namespaces: [0, 118]
-        Content translation:
-            link: Wikipedia:Content translation tool
+        OABot:
+            tag: 'OAuth CID: 817'
+            link: Project:OABOT
+            namespaces: [0, 2]
+        Ohconfucius script:
+            regex: '\[\[(User:Ohconfucius\/.*?|WP:MOSNUMscript)\|script'
+            link: Project:MOSNUMscript
+            namespaces: [0, 2, 118]
+        Page curation:
+            regex: 'using \[\[Wikipedia:Page Curation\|Page Curation'
+            link: w:en:Wikipedia:Page_Curation/Help
+            namespaces: [0, 2, 3]
+        Pending changes revert:
+            regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) \d+ (\[\[Wikipedia:Pending changes\|pending\]\]|pending) edits? (to revision \d+|by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\])'
+            link: Project:Pending changes
+            revert: true
+            namespaces: [0]
         ProveIt:
             regex: 'with \[\[Wikipedia:ProveIt'
             link: Wikipedia:ProveIt
             namespaces: [0, 2, 118]
-        JWB:
-            regex: 'via (JWB|\[\[WP:JWB\]\])'
-            link: WP:JWB
-        Snuggle:
-            regex: 'WP:Snuggle\|Sn\]\]'
-            link: Project:Snuggle
-        unblock-review:
-            regex: '\(\[\[User:Enterprisey\/unblock-review'
-            link: User:Enterprisey/unblock-review
-            namespaces: [3]
-        stubsearch:
-            regex: '\[\[User:Danski454\/stubsearch\|a tool'
-            link: User:Danski454/stubsearch
-            namespaces: [0]
-        YABBR:
-            tag: 'OAuth CID: 860'
-            link: User:Enterprisey/YABBR
-            namespaces: [0]
-        effp-helper:
-            regex: '\(\[\[User:Suffusion of Yellow\/effp-helper(\.js)?\|effp-helper\]\]\)'
-            link: User:Suffusion of Yellow/effp-helper
+        Rater:
+            regex: '\[\[User:(Evad37\/rater.js|Kephir\/gadgets\/rater)'
+            link: User:Evad37/rater.js
+            talk_namespaces: true
+        Redirect:
+            regex: '\[\[WP:AES\|←\]\]Redirected page to \[\[.*?\]\]'
+            link: Project:Redirect
+        Red Link Recovery Live:
+            regex: '\[\[w:en:WP:RLR\|You can help!'
+            link: en:WP:RLR
+        Reflinks:
+            regex: '\[\[(tools:~dispenser\/view\/Reflinks|WP:REFLINKS)\|Reflinks'
+            link: Project:REFLINKS
         Reply link:
             regex: '\(\[\[w:en:User:Enterprisey\/reply-link\|reply-link\]\]\)'
             link: User:Enterprisey/reply-link
             talk_namespaces: true,
             contribs: true
+        responseHelper:
+            regex: '\(using \[\[User:MusikAnimal\/responseHelper\|responseHelper'
+            link: User:MusikAnimal/responseHelper
+            namespaces: [4]
+        revdel:
+            regex: 'using \[\[User:Primefac\/revdel|User:Enterprisey\/cv-revdel\|'
+            link: User:Enterprisey/cv-revdel
+        Sagittarius:
+            regex: '\(\[\[User:Kephir\/gadgets\/sagittarius\||\(\[\[User:Sam Sailor\/Scripts\/Sagittarius\+\|'
+            link: User:Sam Sailor/Scripts/Sagittarius+
+        Script Installer:
+            regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer|\(\[\[User:Enterprisey\/script-installer\|script-installer\]\]\)'
+            link: User:Enterprisey/script-installer
+            namespaces: [2]
         Short description:
             regex: '\(\[\[User:Galobtter\/Shortdesc helper\|Shortdesc helper\]\]\)'
             link: User:Galobtter/Shortdesc helper
             namespaces: [0]
+        Snuggle:
+            regex: 'WP:Snuggle\|Sn\]\]'
+            link: Project:Snuggle
+        SPI Helper:
+            regex: '^(Archiving case (to|from)|Adding sockpuppetry (tag|block notice) per) \[\[Wikipedia:Sockpuppet investigations'
+            link: User:Timotheus Canens/spihelper.js
+            namespaces: [2, 3, 4]
+        STiki:
+            regex: 'WP:(STiki|STIKI)'
+            link: w:en:Wikipedia:STiki
+            revert: Reverted \d+.*WP:(STiki|STIKI)
+        stubsearch:
+            regex: '\[\[User:Danski454\/stubsearch\|a tool'
+            link: User:Danski454/stubsearch
+            namespaces: [0]
+        stubtagtab.js:
+            regex: 'using \[\[User:MC10\/stubtagtab.js'
+            link: User:MC10/stubtagtab.js
+            namespaces: [0]
+        The Wikipedia Adventure:
+            regex: 'simulated automatically as part of \[\[WP:The Wikipedia Adventure\|'
+            link: Project:TWA
+            namespaces: [2]
+        Twinkle:
+            regex: '(Wikipedia|WP):(TW|TWINKLE|Twinkle|FRIENDLY)'
+            link: Project:Twinkle
+            revert: '(Reverted to revision|Reverted \d+ edits).*(WP:(TW|TWINKLE|Twinkle)|Wikipedia:Twinkle)'
+        unblock-review:
+            regex: '\(\[\[User:Enterprisey\/unblock-review'
+            link: User:Enterprisey/unblock-review
+            namespaces: [3]
         undo-last-edit:
             regex: '\(\[\[User:Enterprisey\/undo-last-edit\.js\|undo-last-edit\]\]\)'
             link: User:Enterprisey/undo-last-edit
             revert: true
+        Vada:
+            regex: '\(\[\[WP:Vada\]\]\)'
+            link: Project:Vada
+        WikiLove:
+            regex: 'new WikiLove message'
+            link: Project:WikiLove
+            namespaces: [3]
+        WikiPatroller:
+            regex: 'User:Jfmantis\/WikiPatroller'
+            link: User:Jfmantis/WikiPatroller
+            namespaces: [0, 3]
+        XFDCloser:
+            regex: '\[\[WP:XFDC\|XFDcloser'
+            link: User:Evad37/XFDcloser.js
+        Xunlink:
+            regex: '\(\[\[User:Evad37\/Xunlink'
+            link: User:Evad37/Xunlink
+            namespaces: [0, 10, 100, 118]
+        YABBR:
+            tag: 'OAuth CID: 860'
+            link: User:Enterprisey/YABBR
+            namespaces: [0]
     ko.wikipedia.org:
         AutoWikiBrowser:
             regex: '위키백과:AWB\|AWB|(Wikipedia|WP|Project):(AWB|AutoWikiBrowser)'

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -179,7 +179,7 @@ parameters:
         WPCleaner:
             link: ويكيبيديا:وب_كلينر
             label: وب_كلينر
-        de.wikipedia.org:
+    de.wikipedia.org:
         Generic rollback:
             link: Wikipedia:Zurücksetzen
         Page move:

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -152,8 +152,15 @@ parameters:
 
     # Per-wiki lists
     ar.wikipedia.org:
+        AutoWikiBrowser:
+            regex: 'Project:أوب'
+            link: ويكيبيديا:أوتوويكي_براوزر
         Generic rollback:
             regex: 'استرجاع تعديلات.*حتى آخر نسخة بواسطة'
+        HotCat:
+            regex: 'باستخدام \[\[ويكيبيديا:المصناف الفوري'
+            link: ويكيبيديا:المصناف الفوري
+            label: المصناف الفوري
         Huggle:
             regex: '\(\[\[ويكيبيديا:هغل'
             link: ويكيبيديا:هغل
@@ -162,47 +169,20 @@ parameters:
             regex: 'نقل.*?صفحة \[\[.*?إلى \[\['
             link: ويكيبيديا:نقل_صفحة
             label: نقل_صفحة
-        AutoWikiBrowser:
-            regex: 'Project:أوب'
-            link: ويكيبيديا:أوتوويكي_براوزر
-        HotCat:
-            regex: 'باستخدام \[\[ويكيبيديا:المصناف الفوري'
-            link: ويكيبيديا:المصناف الفوري
-            label: المصناف الفوري
         Popups:
             link: ويكيبيديا:المنبثقات
             label: المنبثقات
-        WPCleaner:
-            link: ويكيبيديا:وب_كلينر
-            label: وب_كلينر
         Rater:
             regex: '\[\[(:User:FShbib\/المقيم|ويكيبيديا:المقيم)'
             link: مستخدم:FShbib/المقيم
             talk_namespaces: true
+        WPCleaner:
+            link: ويكيبيديا:وب_كلينر
+            label: وب_كلينر
     commons.wikimedia.org:
-        UploadWizard:
-            regex: '^User created page with UploadWizard$'
-            link: Special:MyLanguage/Commons:Upload Wizard
-            namespaces: [6]
-        VisualFileChange:
-            regex: 'Using \[\[COM:VFC'
-            tag: VisualFileChange
-            link: Special:MyLanguage/Help:VisualFileChange.js
         AjaxQuickDelete:
             regex: '^(This category needs discussion|\[\[:.*?\]\] needs discussion|Starting category discussion|Nominating for deletion|\[\[:.*?\]\] has been nominated for deletion|Starting deletion request|Listing \[\[.*?\]\])$|#Autoreport by AjaxQuickDelete|^Updating redirect while processing'
             link: Special:MyLanguage/Help:Nominate_for_deletion
-        QuickDelete:
-            regex: '^(Marking as possible copyvio because|Notification of possible copyright violation for|\[\[.*?\]\] does not have a source|Please send permission for \[\[|\]\] does not have a license)|^(File has no source|Missing permission)$'
-            link: Special:MyLanguage/Help:QuickDelete
-            namespaces: [3, 6]
-        POTY:
-            regex: '\[\[Help:(?:Gadget-)EnhancedPOTY.js|POTY App\]\]$'
-            link: Help:Gadget-EnhancedPOTY.js
-            namespaces: [4]
-        Flickr2Commons:
-            regex: 'via \[\[(?:Special:MyLanguage\/)?Commons:Flickr2Commons'
-            link: Special:MyLanguage/Commons:Flickr2Commons
-            namespaces: [6]
         Android Commons:
             regex: '^Uploaded using Android Commons app$'
             link: Special:MyLanguage/Commons:Mobile_app
@@ -211,30 +191,50 @@ parameters:
             regex: '^commonist \d\.\d'
             link: Special:MyLanguage/Commons:Commonist
             namespaces: [6]
-        RenameLink:
-            regex: '^\(\[\[Help:RenameLink\|Script'
-            link: Special:MyLanguage/Help:RenameLink
+        Flickr2Commons:
+            regex: 'via \[\[(?:Special:MyLanguage\/)?Commons:Flickr2Commons'
+            link: Special:MyLanguage/Commons:Flickr2Commons
+            namespaces: [6]
         Geograph2commons:
             regex: 'Transferred from geograph.co.uk using'
             link: Special:GoToInterwiki/toollabs:geograph2commons
             namespaces: [6]
-        SettingsManager:
-            regex: '\[\[MediaWiki:Gadget-SettingsManager.js\|SettingsManager'
-            link: MediaWiki:Gadget-SettingsManager.js
+        POTY:
+            regex: '\[\[Help:(?:Gadget-)EnhancedPOTY.js|POTY App\]\]$'
+            link: Help:Gadget-EnhancedPOTY.js
+            namespaces: [4]
+        QuickDelete:
+            regex: '^(Marking as possible copyvio because|Notification of possible copyright violation for|\[\[.*?\]\] does not have a source|Please send permission for \[\[|\]\] does not have a license)|^(File has no source|Missing permission)$'
+            link: Special:MyLanguage/Help:QuickDelete
+            namespaces: [3, 6]
+        RenameLink:
+            regex: '^\(\[\[Help:RenameLink\|Script'
+            link: Special:MyLanguage/Help:RenameLink
         RotateLink:
             regex: '\(\[\[Help:RotateLink\|Script'
             link: Help:RotateLink
+        SettingsManager:
+            regex: '\[\[MediaWiki:Gadget-SettingsManager.js\|SettingsManager'
+            link: MediaWiki:Gadget-SettingsManager.js
+        UploadWizard:
+            regex: '^User created page with UploadWizard$'
+            link: Special:MyLanguage/Commons:Upload Wizard
+            namespaces: [6]
+        VisualFileChange:
+            regex: 'Using \[\[COM:VFC'
+            tag: VisualFileChange
+            link: Special:MyLanguage/Help:VisualFileChange.js
     de.wikipedia.org:
         Generic rollback:
             link: Wikipedia:Zurücksetzen
         Page move:
             link: Hilfe:Seite verschieben
-        Redirect:
-            link: Wikipedia:Weiterleitung
         Popups:
             regex: 'Wikipedia:Helferlein\/Navigation-Popups\|Popups'
             link: Wikipedia:Helferlein/Navigation-Popups
             label: Navigation-Popups
+        Redirect:
+            link: Wikipedia:Weiterleitung
     de.wiktionary.org:
         Einfügen-Erweiterung:
             regex: \[\[Hilfe:Einfügen-Erweiterung\|
@@ -489,34 +489,34 @@ parameters:
             label: 위키사랑
             namespaces: [3]
     pt.wikipedia.org:
-        Undo:
-            regex: 'Desfeita a edição \d+ de \[\['
-            link: Ajuda:Guia de edição/Reverter edições#Botão Desfazer
-            label: 'Desfazer'
-        FastButtons:
-            regex: '\|FastButtons\]\]'
-            link: Wikipédia:FastButtons
-        Script de ajustes:
-            regex: 'usando \[\[[Uu]ser:Luizdl/Script de ajustes.js'
-            link: User:Luizdl/Script de ajustes.js
         Automatic Page Corrector:
             tag: apc
             regex: '\+correções \[\[WP:SR\|semiautomáticas'
             link: Wikipédia:Scripts/APC
-        Popups:
-            link: Wikipédia:Software/Popups de navegação
-            label: Popups de navegação
-        Page move:
-            link: Ajuda:Guia de edição/Mover páginas
-        reFill:
-            link: en:Project:ReFill
+        FastButtons:
+            regex: '\|FastButtons\]\]'
+            link: Wikipédia:FastButtons
         Generic rollback:
             link: Wikipédia:Reversores
             label: Reversão
+        Page move:
+            link: Ajuda:Guia de edição/Mover páginas
+        Popups:
+            link: Wikipédia:Software/Popups de navegação
+            label: Popups de navegação
+        reFill:
+            link: en:Project:ReFill
+        Script de ajustes:
+            regex: 'usando \[\[[Uu]ser:Luizdl/Script de ajustes.js'
+            link: User:Luizdl/Script de ajustes.js
+        Undo:
+            regex: 'Desfeita a edição \d+ de \[\['
+            link: Ajuda:Guia de edição/Reverter edições#Botão Desfazer
+            label: 'Desfazer'
     www.wikidata.org:
-        RequestDeletion:
-            regex: '\[\[MediaWiki talk:Gadget-RequestDeletion\.js\|RD\]\]'
-            link: MediaWiki talk:Gadget-RequestDeletion.js
         QuickStatements:
             regex: '#quickstatements'
             link: Help:QuickStatements
+        RequestDeletion:
+            regex: '\[\[MediaWiki talk:Gadget-RequestDeletion\.js\|RD\]\]'
+            link: MediaWiki talk:Gadget-RequestDeletion.js


### PR DESCRIPTION
Alphabetize tools lists, separate global overrides from local tools, move commons out of the wikipedias and group it with wikidata, etc. No change in functionality should have occurred.
Bug: T222327