### PR TITLE
i18n: clarify pc-reject

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -309,7 +309,7 @@
 	"patrols": "Patrols",
 	"patrols-desc": "$2 {{PLURAL:$1|article|articles}} patrolled",
 	"pc-accept": "Pending change accept",
-	"pc-reject": "Pending change reject",
+	"pc-reject": "Pending change unaccept",
 	"page-curation": "Page curation",
 	"percent-of-edit-count": "% of edit count",
 	"percent-of-tools": "% of tools",


### PR DESCRIPTION
Change pc-reject from "Pending changes reject" to "Pending changes unaccept" since the actual action that is logged is to unaccept the revision. For example, Patroller stats currently lists DannyS712 as having 0 "Pending changes reject", while autoedits lists the same user as having 153 "Pending changes revert edits". This is because autoedits tracks the edits themselves, while patrollerstats tracks log entries. The heading for the log entry column should correspond to the actual content, in this case unaccepting revisions.