### PR TITLE
AutoEdits: Expand incomplete namespace definitions

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -341,7 +341,7 @@ parameters:
             regex: '^(\[\[Help:Reverting\|Reverted\]\]|Reverted) \d+ (\[\[Wikipedia:Pending changes\|pending\]\]|pending) edits? (to revision \d+|by \[\[Special:(Contribs|Contributions)\/.*?\|.*?\]\])'
             link: Project:Pending changes
             revert: true
-            namespaces: [0]
+            namespaces: [0, 4]
         Rater:
             regex: '\[\[User:(Evad37\/rater.js|Kephir\/gadgets\/rater)'
             link: User:Evad37/rater.js

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -397,7 +397,7 @@ parameters:
         The Wikipedia Adventure:
             regex: 'simulated automatically as part of \[\[WP:The Wikipedia Adventure\|'
             link: Project:TWA
-            namespaces: [2]
+            namespaces: [2, 3]
         Twinkle:
             regex: '(Wikipedia|WP):(TW|TWINKLE|Twinkle|FRIENDLY)'
             link: Project:Twinkle


### PR DESCRIPTION
Per https://gerrit.wikimedia.org/r/plugins/gitiles/operations/mediawiki-config/+/refs/heads/master/wmf-config/flaggedrevs.php#225, pending changes are enabled in both mainspace (ns:0) and the wikipedia namespace (ns:4)
Bug: T222323