### PR TITLE
EditCounter: refactor views; rm global contribs as subtool

### DIFF
--- a/src/AppBundle/Controller/EditCounterController.php
+++ b/src/AppBundle/Controller/EditCounterController.php
@@ -40,7 +40,6 @@ class EditCounterController extends XtoolsController
         'timecard' => 'EditCounterTimecard',
         'top-edited-pages' => 'TopEditsResultNamespace',
         'rights-changes' => 'EditCounterRightsChanges',
-        'latest-global-edits' => 'GlobalContribsResult',
     ];
 
     /** @var EditCounter The edit-counter, that does all the work. */
@@ -275,6 +274,7 @@ class EditCounterController extends XtoolsController
         $ret = [
             'xtTitle' => $this->user->getUsername(),
             'xtPage' => 'EditCounter',
+            'subtool_msg_key' => 'general-stats',
             'is_sub_request' => $this->isSubRequest,
             'user' => $this->user,
             'project' => $this->project,
@@ -310,6 +310,7 @@ class EditCounterController extends XtoolsController
         $ret = [
             'xtTitle' => $this->user->getUsername(),
             'xtPage' => 'EditCounter',
+            'subtool_msg_key' => 'namespace-totals',
             'is_sub_request' => $this->isSubRequest,
             'user' => $this->user,
             'project' => $this->project,
@@ -344,6 +345,7 @@ class EditCounterController extends XtoolsController
         $ret = [
             'xtTitle' => $this->user->getUsername(),
             'xtPage' => 'EditCounter',
+            'subtool_msg_key' => 'timecard',
             'is_sub_request' => $this->isSubRequest,
             'user' => $this->user,
             'project' => $this->project,
@@ -379,6 +381,7 @@ class EditCounterController extends XtoolsController
         $ret = [
             'xtTitle' => $this->user->getUsername(),
             'xtPage' => 'EditCounter',
+            'subtool_msg_key' => 'year-counts',
             'is_sub_request' => $this->isSubRequest,
             'user' => $this->user,
             'project' => $this->project,
@@ -413,6 +416,7 @@ class EditCounterController extends XtoolsController
         $ret = [
             'xtTitle' => $this->user->getUsername(),
             'xtPage' => 'EditCounter',
+            'subtool_msg_key' => 'month-counts',
             'is_sub_request' => $this->isSubRequest,
             'user' => $this->user,
             'project' => $this->project,

--- a/templates/editCounter/general_stats.html.twig
+++ b/templates/editCounter/general_stats.html.twig
@@ -1,35 +1,14 @@
-{% extends is_sub_request ? 'subrequest.html.twig' : 'base.html.twig' %}
+{% extends is_sub_request ? 'subrequest.html.twig' : 'editCounter/subtool.html.twig' %}
 {% import 'macros/layout.html.twig' as layout %}
 {% import 'macros/wiki.html.twig' as wiki %}
 {% import 'macros/layout.html.twig' as layout %}
 {% import 'macros/pieChart.html.twig' as chart %}
 
-{% block body %}
+{% block downloadLink %}
+    {{ layout.downloadLink('EditCounterGeneralStats', {project:project.domain, username:user.username}, ['wikitext']) }}
+{% endblock %}
 
-{% if not is_sub_request %}
-    <div class="panel panel-primary">
-        <header class="panel-heading">
-            <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
-                    <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('see-full-statistics') }}
-                </a>
-                {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.title }} </small>
-            </div>
-        </header>
-        <div class="panel-body xt-panel-body">
-            <section class="panel panel-default clearfix">
-                <header class="panel-heading col-lg-12">
-                    <h4>
-                        {{ msg('general-stats') }}
-                        <span class='pull-right text-muted xt-panel-description'>
-                            {{ layout.downloadLink('EditCounterGeneralStats', {project:project.domain, username:user.username}, ['wikitext']) }}
-                        </span>
-                    </h4>
-                </header>
-                <div class="panel-body col-lg-12">
-{% endif %}
+{% block ecBody %}
 
 <div class="col-lg-6 stat-list clearfix">
     <table class="table"><tbody class="stat-list--group">
@@ -471,7 +450,7 @@
                     <td>
                         <strong>
                             {% if is_sub_request %}
-                                <a href="#latest-global-edits">{{ gc.globalEditCount|num_format }}</a>
+                                <a href="{{ path('GlobalContribsResult', { username: user.username }) }}">{{ gc.globalEditCount|num_format }}</a>
                             {% else %}
                                 <a href="{{ path('GlobalContribsResult', {username:user.username}) }}">
                                     {{ gc.globalEditCount|num_format }}
@@ -533,14 +512,6 @@
             * {{ msg('data-limit', [5000, 5000|num_format]) }}
         </div>
     </div>
-{% endif %}
-
-{% if not is_sub_request %}
-    </div></section>
-    <div class="text-muted times-in-utc" style="clear:both">
-        {{ msg('times-in-utc') }}
-    </div>
-    </div></div>
 {% endif %}
 
 {% endblock %}

--- a/templates/editCounter/monthcounts.html.twig
+++ b/templates/editCounter/monthcounts.html.twig
@@ -1,33 +1,12 @@
-{% extends is_sub_request ? 'subrequest.html.twig' : 'base.html.twig' %}
+{% extends is_sub_request ? 'subrequest.html.twig' : 'editCounter/subtool.html.twig' %}
 {% import 'macros/wiki.html.twig' as wiki %}
 {% import 'macros/layout.html.twig' as layout %}
 
-{% block body %}
+{% block downloadLink %}
+    {{ layout.downloadLink('EditCounterMonthCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
+{% endblock %}
 
-{% if not is_sub_request %}
-    <div class="panel panel-primary">
-        <header class="panel-heading">
-            <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
-                    <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('see-full-statistics') }}
-                </a>
-                {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.domain }} </small>
-            </div>
-        </header>
-        <div class="panel-body xt-panel-body">
-            <section class="panel panel-default clearfix">
-                <header class="panel-heading col-lg-12">
-                    <h4>
-                        {{ msg('month-counts') }}
-                        <span class='pull-right text-muted xt-panel-description'>
-                            {{ layout.downloadLink('EditCounterMonthCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-                        </span>
-                    </h4>
-                </header>
-                <div class="panel-body col-lg-12">
-{% endif %}
+{% block ecBody %}
 
 {% if not project.userHasOptedIn(user) %}
     <div class="alert alert-info">
@@ -108,10 +87,6 @@
     </div>
 {% endif %}
 
-{% endif %}
-
-{% if not is_sub_request %}
-    </div></section></div></div>
 {% endif %}
 
 {% endblock %}

--- a/templates/editCounter/namespace_totals.html.twig
+++ b/templates/editCounter/namespace_totals.html.twig
@@ -1,33 +1,12 @@
-{% extends is_sub_request ? 'subrequest.html.twig' : 'base.html.twig' %}
+{% extends is_sub_request ? 'subrequest.html.twig' : 'editCounter/subtool.html.twig' %}
 {% import 'macros/wiki.html.twig' as wiki %}
 {% import 'macros/layout.html.twig' as layout %}
 
-{% block body %}
+{% block downloadLink %}
+    {{ layout.downloadLink('EditCounterNamespaceTotals', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
+{% endblock %}
 
-{% if not is_sub_request %}
-    <div class="panel panel-primary">
-        <header class="panel-heading">
-            <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
-                    <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('see-full-statistics') }}
-                </a>
-                {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.domain }} </small>
-            </div>
-        </header>
-        <div class="panel-body xt-panel-body">
-            <section class="panel panel-default clearfix">
-                <header class="panel-heading col-lg-12">
-                    <h4>
-                        {{ msg('namespace-totals') }}
-                        <span class='pull-right text-muted xt-panel-description'>
-                            {{ layout.downloadLink('EditCounterNamespaceTotals', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-                        </span>
-                    </h4>
-                </header>
-                <div class="panel-body col-lg-12">
-{% endif %}
+{% block ecBody %}
 
 {% if ec.namespaceTotals|length > 0 %}
     <table class="table table-bordered table-hover table-striped namespaces-table toggle-table">
@@ -124,10 +103,6 @@
     <div class="alert alert-info">
         {{ msg('no-contribs') }}
     </div>
-{% endif %}
-
-{% if not is_sub_request %}
-    </div></section></div></div>
 {% endif %}
 
 {% endblock %}

--- a/templates/editCounter/result.html.twig
+++ b/templates/editCounter/result.html.twig
@@ -26,140 +26,20 @@
             {% endfor %}
         </div>
 
-        {% if 'general-stats' in sections %}
-            {% set content %}
-                {{ render(path('EditCounterGeneralStats', {
-                    'username': user.username,
-                    'project': project.domain
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('EditCounterGeneralStats', {project:project.domain, username:user.username})}}">{{ msg('general-stats') }}</a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('EditCounterGeneralStats', {project:project.domain, username:user.username}, ['wikitext']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'general-stats', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterGeneralStats', 'i18nKey': 'general-stats'} %}
 
-        {% if 'namespace-totals' in sections %}
-            {% set content %}
-                {{ render(path('EditCounterNamespaceTotals', {
-                    'username': user.username,
-                    'project': project.domain
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('EditCounterNamespaceTotals', {project:project.domain, username:user.username})}}">{{ msg('namespace-totals') }}</a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('EditCounterNamespaceTotals', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'namespace-totals', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterNamespaceTotals', 'i18nKey': 'namespace-totals'} %}
 
-        {% if 'year-counts' in sections %}
-            {% set content %}
-                {{ render(path('EditCounterYearCounts', {
-                    'username': user.username,
-                    'project': project.domain
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('EditCounterYearCounts', {project:project.domain, username:user.username})}}">{{ msg('year-counts') }}</a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('EditCounterYearCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'year-counts', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterYearCounts', 'i18nKey': 'year-counts'} %}
 
-        {% if 'month-counts' in sections %}
-            {% set content %}
-                {{ render(path('EditCounterMonthCounts', {
-                    'username': user.username,
-                    'project': project.domain
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('EditCounterMonthCounts', {project:project.domain, username:user.username})}}">
-                    {{ msg('month-counts') }}
-                </a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('EditCounterMonthCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'month-counts', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterMonthCounts', 'i18nKey': 'month-counts'} %}
 
-        {% if 'timecard' in sections %}
-            {% set content %}
-                {{ render(path('EditCounterTimecard', {
-                    'username': user.username,
-                    'project': project.domain
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('EditCounterTimecard', {project:project.domain, username:user.username})}}">{{ msg('timecard') }}</a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('EditCounterTimecard', {project:project.domain, username:user.username}, ['wikitext']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'timecard', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterTimecard', 'i18nKey': 'timecard'} %}
 
-        {% if 'top-edited-pages' in sections %}
-            {% set content %}
-                {{ render(path('TopEditsResultNamespace', {
-                    'username': user.username,
-                    'project': project.domain,
-                    'namespace': 'all'
-                })) }}
-            {% endset %}
-            {% set headerLink %}
-                <a href="{{ path('TopEditsResultNamespace', {project:project.domain, username:user.username, namespace:'all'})}}">{{ msg('top-edited-pages') }}</a>
-            {% endset %}
-            {% set downloadLink %}
-                {{ layout.downloadLink('TopEditsResultNamespace', {project:project.domain, username:user.username, namespace:'all'}, ['wikitext']) }}
-            {% endset %}
-            {{ layout.content_block(headerLink, content, downloadLink, 'top-edited-pages', true) }}
-        {% endif %}
+        {% include 'editCounter/subtoolSection.html.twig' with {'route': 'TopEditsResultNamespace', 'i18nKey': 'top-edited-pages', 'downloadFormats': ['wikitext'], 'extraParams': {'namespace': 'all'}} %}
 
-        {% if not(user.anon) %}
-            {% if 'rights-changes' in sections and (ec.rightsChanges|length > 0 or ec.globalRightsChanges|length > 0) %}
-                {% set content %}
-                    {% include 'editCounter/rights_changes.html.twig' with {
-                        'is_sub_request': true,
-                        'project': project,
-                        'user': user,
-                        'ec': ec
-                    } %}
-                {% endset %}
-                {% set headerLink %}
-                    <a href="{{ path('EditCounterRightsChanges', {project:project.domain, username:user.username})}}">{{ msg('rights-changes') }}</a>
-                {% endset %}
-                {% set downloadLink %}
-                    {{ layout.downloadLink('EditCounterRightsChanges', {project:project.domain, username:user.username}, ['wikitext']) }}
-                {% endset %}
-                {{ layout.content_block(headerLink, content, downloadLink, 'rights-changes', true) }}
-            {% endif %}
-
-            {% if 'latest-global-edits' in sections %}
-                {% set content %}
-                    <em class="contributions-loading text-muted">{{ msg('loading') }}...</em>
-                    <div id="latestglobal-container" class="contributions-container"
-                        data-project="{{ project.domain }}"
-                        data-username="{{ user.username }}"
-                        data-offset="0"
-                        data-target="ec-latestglobal"
-                        data-pagesize="30">
-                    </div>
-                {% endset %}
-                {% set headerLink %}
-                    <a href="{{ path('EditCounterLatestGlobal', {project:project.domain, username:user.username})}}">{{ msg('latest-global-edits') }}</a>
-                {% endset %}
-                {{ layout.content_block(headerLink, content, '', 'latest-global-edits', true) }}
-            {% endif %}
+        {% if not(user.anon) and 'rights-changes' in sections and (ec.rightsChanges|length > 0 or ec.globalRightsChanges|length > 0) %}
+            {% include 'editCounter/subtoolSection.html.twig' with {'route': 'EditCounterRightsChanges', 'i18nKey': 'rights-changes', 'downloadFormats': ['wikitext']} %}
         {% endif %}
 
         <div class="text-muted times-in-utc">

--- a/templates/editCounter/rights_changes.html.twig
+++ b/templates/editCounter/rights_changes.html.twig
@@ -93,11 +93,11 @@
     </div>
 {% endif %}
 
-<div class="text-muted times-in-utc">
-    {{ msg('times-in-utc') }}
-</div>
-
 {% if not is_sub_request %}
+    <div class="text-muted times-in-utc" style="clear:both">
+        {{ msg('times-in-utc') }}
+    </div>
+
     </div></section></div></div>
 {% endif %}
 

--- a/templates/editCounter/subtool.html.twig
+++ b/templates/editCounter/subtool.html.twig
@@ -1,0 +1,38 @@
+{% extends 'base.html.twig' %}
+{% import 'macros/wiki.html.twig' as wiki %}
+
+{% block body %}
+<div class="panel panel-primary">
+    <header class="panel-heading">
+        <div class="text-center xt-heading-top">
+            <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
+                <span class="glyphicon glyphicon-chevron-left"></span>
+                {{ msg('see-full-statistics') }}
+            </a>
+            {{ wiki.userLink(user, project) }}
+            <small> &bull; {{ project.domain }}</small>
+        </div>
+    </header>
+    <div class="panel-body xt-panel-body">
+        <section class="panel panel-default clearfix">
+            <header class="panel-heading col-lg-12">
+                <h4>
+                    {{ msg(subtool_msg_key) }}
+                    <span class='pull-right text-muted xt-panel-description'>
+                        {% block downloadLink %}{% endblock %}
+                    </span>
+                </h4>
+            </header>
+            <div class="panel-body col-lg-12">
+                {% block ecBody %}{% endblock %}
+            </div>
+        </section>
+
+        {% if subtool_msg_key == 'general-stats' %}
+            <div class="text-muted times-in-utc" style="clear:both">
+                {{ msg('times-in-utc') }}
+            </div>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/editCounter/subtoolSection.html.twig
+++ b/templates/editCounter/subtoolSection.html.twig
@@ -1,0 +1,20 @@
+{% import 'macros/layout.html.twig' as layout %}
+
+{% if downloadFormats is not defined %}
+    {% set downloadFormats = ['wikitext', 'csv'] %}
+{% endif %}
+{% if extraParams is not defined %}
+    {% set extraParams = {} %}
+{% endif %}
+{% if i18nKey in sections %}
+    {% set content %}
+        {{ render(path(route, {'username': user.username, 'project': project.domain}|merge(extraParams))) }}
+    {% endset %}
+    {% set headerLink %}
+        <a href="{{ path(route, {project:project.domain, username:user.username}|merge(extraParams))}}">{{ msg(i18nKey) }}</a>
+    {% endset %}
+    {% set downloadLink %}
+        {{ layout.downloadLink(route, {project:project.domain, username:user.username}|merge(extraParams), downloadFormats) }}
+    {% endset %}
+    {{ layout.content_block(headerLink, content, downloadLink, i18nKey, true) }}
+{% endif %}

--- a/templates/editCounter/timecard.html.twig
+++ b/templates/editCounter/timecard.html.twig
@@ -1,33 +1,12 @@
-{% extends is_sub_request ? 'subrequest.html.twig' : 'base.html.twig' %}
+{% extends is_sub_request ? 'subrequest.html.twig' : 'editCounter/subtool.html.twig' %}
 {% import 'macros/wiki.html.twig' as wiki %}
 {% import 'macros/layout.html.twig' as layout %}
 
-{% block body %}
+{% block downloadLink %}
+    {{ layout.downloadLink('EditCounterTimecard', {project:project.domain, username:user.username}, ['wikitext']) }}
+{% endblock %}
 
-{% if not is_sub_request %}
-    <div class="panel panel-primary">
-        <header class="panel-heading">
-            <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
-                    <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('see-full-statistics') }}
-                </a>
-                {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.domain }} </small>
-            </div>
-        </header>
-        <div class="panel-body xt-panel-body">
-            <section class="panel panel-default clearfix">
-                <header class="panel-heading col-lg-12">
-                    <h4>
-                        {{ msg('timecard') }}
-                        <span class='pull-right text-muted xt-panel-description'>
-                            {{ layout.downloadLink('EditCounterTimecard', {project:project.domain, username:user.username}, ['wikitext']) }}
-                        </span>
-                    </h4>
-                </header>
-                <div class="panel-body col-lg-12">
-{% endif %}
+{% block ecBody %}
 
 {% if not project.userHasOptedIn(user) %}
 <div class="alert alert-info">
@@ -171,10 +150,6 @@
     {{ msg('times-in-utc') }}
 </div>
 
-{% endif %}
-
-{% if not is_sub_request %}
-    </div></section></div></div>
 {% endif %}
 
 {% endblock %}

--- a/templates/editCounter/yearcounts.html.twig
+++ b/templates/editCounter/yearcounts.html.twig
@@ -1,33 +1,12 @@
-{% extends is_sub_request ? 'subrequest.html.twig' : 'base.html.twig' %}
+{% extends is_sub_request ? 'subrequest.html.twig' : 'editCounter/subtool.html.twig' %}
 {% import 'macros/wiki.html.twig' as wiki %}
 {% import 'macros/layout.html.twig' as layout %}
 
-{% block body %}
+{% block downloadLink %}
+    {{ layout.downloadLink('EditCounterYearCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
+{% endblock %}
 
-{% if not is_sub_request %}
-    <div class="panel panel-primary">
-        <header class="panel-heading">
-            <div class="text-center xt-heading-top">
-                <a class="back-to-search" href="{{ path('EditCounterResult', {project: project.domain, username:user.username}) }}">
-                    <span class="glyphicon glyphicon-chevron-left"></span>
-                    {{ msg('see-full-statistics') }}
-                </a>
-                {{ wiki.userLink(user, project) }}
-                <small> &bull; {{ project.domain }} </small>
-            </div>
-        </header>
-        <div class="panel-body xt-panel-body">
-            <section class="panel panel-default clearfix">
-                <header class="panel-heading col-lg-12">
-                    <h4>
-                        {{ msg('year-counts') }}
-                        <span class='pull-right text-muted xt-panel-description'>
-                            {{ layout.downloadLink('EditCounterYearCounts', {project:project.domain, username:user.username}, ['wikitext', 'csv']) }}
-                        </span>
-                    </h4>
-                </header>
-                <div class="panel-body col-lg-12">
-{% endif %}
+{% block ecBody %}
 
 {% if ec.yearTotals|length > 0 %}
     <table class="sr-only">
@@ -97,10 +76,6 @@
     <div class="alert alert-info">
         {{ msg('no-contribs') }}
     </div>
-{% endif %}
-
-{% if not is_sub_request %}
-    </div></section></div></div>
 {% endif %}
 
 {% endblock %}

--- a/templates/subrequest.html.twig
+++ b/templates/subrequest.html.twig
@@ -1,4 +1,6 @@
 <div class="subrequest">
-{% block body %}
-{% endblock %}
+{% block body %}{% endblock %}
+
+{# For the Edit Counter pages #}
+{% block ecBody %}{% endblock %}
 </div>


### PR DESCRIPTION
Most users don't even look at the global contributions when using the
Edit Counter. It still exists as a standalone tool, it just is being
removed as a subtool of the Edit Counter.