### PR TITLE
Send API responses early, before making database transactions

### DIFF
--- a/src/AppBundle/Controller/AdminStatsController.php
+++ b/src/AppBundle/Controller/AdminStatsController.php
@@ -184,19 +184,28 @@ class AdminStatsController extends XtoolsController
     {
         $adminStatsRepo = new AdminStatsRepository();
         $adminStatsRepo->setContainer($this->container);
-        $group = $this->params['group'] ?? 'admin';
+        $group = $this->getGroup();
 
         $this->adminStats = new AdminStats(
             $this->normalizeProject($group),
             (int)$this->start,
             (int)$this->end,
-            $group ?? 'admin',
+            $group,
             $this->getAndSetRequestedActions()
         );
         $this->adminStats->setRepository($adminStatsRepo);
 
         // For testing purposes.
         return $this->adminStats;
+    }
+
+    /**
+     * Get the requested group (e.g. 'admin', 'patroller' or 'stewards').
+     * @return string
+     */
+    private function getGroup(): string
+    {
+        return $this->params['group'] ?? 'admin';
     }
 
     /**
@@ -242,8 +251,6 @@ class AdminStatsController extends XtoolsController
      */
     public function adminsGroupsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('project/admins_groups');
-
         $this->setUpAdminStats();
 
         unset($this->params['actions']);
@@ -252,7 +259,7 @@ class AdminStatsController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'users_and_groups' => $this->adminStats->getUsersAndGroups(),
-        ]);
+        ], 'project/admins_groups');
     }
 
     /**
@@ -268,13 +275,11 @@ class AdminStatsController extends XtoolsController
      */
     public function adminStatsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('project/adminstats');
-
         $this->setUpAdminStats();
         $this->adminStats->prepareStats();
 
         return $this->getFormattedApiResponse([
             'users' => $this->adminStats->getStats(),
-        ]);
+        ], 'project/'.$this->getGroup().'stats');
     }
 }

--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -224,8 +224,6 @@ class ArticleInfoController extends XtoolsController
      */
     public function articleInfoApiAction(): Response
     {
-        $this->recordApiUsage('page/articleinfo');
-
         $this->setupArticleInfo();
         $data = $this->articleInfo->getArticleInfoApiData($this->project, $this->page);
 
@@ -233,7 +231,7 @@ class ArticleInfoController extends XtoolsController
             return $this->getApiHtmlResponse($this->project, $this->page, $data);
         }
 
-        return $this->getFormattedApiResponse($data);
+        return $this->getFormattedApiResponse($data, 'page/articleinfo');
     }
 
     /**
@@ -274,10 +272,8 @@ class ArticleInfoController extends XtoolsController
      */
     public function proseStatsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('page/prose');
-
         $this->setupArticleInfo();
-        return $this->getFormattedApiResponse($this->articleInfo->getProseStats());
+        return $this->getFormattedApiResponse($this->articleInfo->getProseStats(), 'page/prose');
     }
 
     /**
@@ -293,8 +289,6 @@ class ArticleInfoController extends XtoolsController
      */
     public function assessmentsApiAction(string $pages): JsonResponse
     {
-        $this->recordApiUsage('page/assessments');
-
         $pages = explode('|', $pages);
         $out = [];
 
@@ -313,7 +307,7 @@ class ArticleInfoController extends XtoolsController
             }
         }
 
-        return $this->getFormattedApiResponse($out);
+        return $this->getFormattedApiResponse($out, 'page/assessments');
     }
 
     /**
@@ -328,8 +322,7 @@ class ArticleInfoController extends XtoolsController
      */
     public function linksApiAction(): JsonResponse
     {
-        $this->recordApiUsage('page/links');
-        return $this->getFormattedApiResponse($this->page->countLinksAndRedirects());
+        return $this->getFormattedApiResponse($this->page->countLinksAndRedirects(), 'page/links');
     }
 
     /**
@@ -353,8 +346,6 @@ class ArticleInfoController extends XtoolsController
      */
     public function topEditorsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('page/top_editors');
-
         $this->setupArticleInfo();
         $topEditors = $this->articleInfo->getTopEditorsByEditCount(
             (int)$this->limit,
@@ -363,6 +354,6 @@ class ArticleInfoController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'top_editors' => $topEditors,
-        ]);
+        ], 'page/top_editors');
     }
 }

--- a/src/AppBundle/Controller/AutomatedEditsController.php
+++ b/src/AppBundle/Controller/AutomatedEditsController.php
@@ -222,10 +222,8 @@ class AutomatedEditsController extends XtoolsController
      */
     public function automatedToolsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('user/automated_tools');
-
         $aeh = $this->container->get('app.automated_edits_helper');
-        return $this->getFormattedApiResponse($aeh->getTools($this->project));
+        return $this->getFormattedApiResponse($aeh->getTools($this->project), 'user/automated_tools');
     }
 
     /**
@@ -246,8 +244,6 @@ class AutomatedEditsController extends XtoolsController
      */
     public function automatedEditCountApiAction(string $tools = ''): JsonResponse
     {
-        $this->recordApiUsage('user/automated_editcount');
-
         $this->setupAutoEdits();
 
         $ret = [
@@ -261,7 +257,7 @@ class AutomatedEditsController extends XtoolsController
             $ret['automated_tools'] = $tools;
         }
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/automated_editcount');
     }
 
     /**
@@ -282,8 +278,6 @@ class AutomatedEditsController extends XtoolsController
      */
     public function nonAutomatedEditsApiAction(): JsonResponse
     {
-        $this->recordApiUsage('user/nonautomated_edits');
-
         $this->setupAutoEdits();
 
         $ret = array_map(function ($rev) {
@@ -296,7 +290,7 @@ class AutomatedEditsController extends XtoolsController
             ], $rev);
         }, $this->autoEdits->getNonAutomatedEdits(true));
 
-        return $this->getFormattedApiResponse(['nonautomated_edits' => $ret]);
+        return $this->getFormattedApiResponse(['nonautomated_edits' => $ret], 'user/nonautomated_edits');
     }
 
     /**
@@ -317,8 +311,6 @@ class AutomatedEditsController extends XtoolsController
      */
     public function automatedEditsApiAction(): Response
     {
-        $this->recordApiUsage('user/automated_edits');
-
         $this->setupAutoEdits();
 
         $ret = [];
@@ -337,6 +329,6 @@ class AutomatedEditsController extends XtoolsController
             ], $rev);
         }, $this->autoEdits->getAutomatedEdits(true));
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/automated_edits');
     }
 }

--- a/src/AppBundle/Controller/CategoryEditsController.php
+++ b/src/AppBundle/Controller/CategoryEditsController.php
@@ -212,8 +212,6 @@ class CategoryEditsController extends XtoolsController
      */
     public function categoryEditCountApiAction(): JsonResponse
     {
-        $this->recordApiUsage('user/category_editcount');
-
         $this->setupCategoryEdits();
 
         $ret = [
@@ -221,6 +219,6 @@ class CategoryEditsController extends XtoolsController
             'category_editcount' => $this->categoryEdits->getCategoryEditCount(),
         ];
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/category_editcount');
     }
 }

--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -9,6 +9,7 @@ namespace AppBundle\Controller;
 
 use AppBundle\Model\Edit;
 use AppBundle\Repository\ProjectRepository;
+use AppBundle\Response\EarlyJsonResponse;
 use MediaWiki\OAuthClient\Client;
 use MediaWiki\OAuthClient\ClientConfig;
 use MediaWiki\OAuthClient\Consumer;
@@ -243,7 +244,7 @@ class DefaultController extends XtoolsController
         return $this->getFormattedApiResponse([
             'project' => $this->project->getDomain(),
             'assessments' => $this->project->getPageAssessments()->getConfig(),
-        ]);
+        ], 'project/assessments');
     }
 
     /**
@@ -254,13 +255,17 @@ class DefaultController extends XtoolsController
     public function assessmentsConfigApiAction(): JsonResponse
     {
         // Here there is no Project, so we don't use XtoolsController::getFormattedApiResponse().
-        $response = new JsonResponse();
+        $response = new EarlyJsonResponse();
         $response->setEncodingOptions(JSON_NUMERIC_CHECK);
         $response->setStatusCode(Response::HTTP_OK);
         $response->setData([
             'projects' => array_keys($this->container->getParameter('assessments')),
             'config' => $this->container->getParameter('assessments'),
         ]);
+        $response->setCallbackAction(function (): void {
+            // Intentionally record this as the same endpoint as ProjectApiAssessments.
+            $this->recordApiUsage('project/assessments');
+        });
 
         return $response;
     }

--- a/src/AppBundle/Controller/EditCounterController.php
+++ b/src/AppBundle/Controller/EditCounterController.php
@@ -491,7 +491,7 @@ class EditCounterController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'log_counts' => $this->editCounter->getLogCounts(),
-        ]);
+        ], 'user/log_counts');
     }
 
     /**
@@ -506,7 +506,7 @@ class EditCounterController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'namespace_totals' => $this->editCounter->namespaceTotals(),
-        ]);
+        ], 'user/namespace_totals');
     }
 
     /**
@@ -525,7 +525,7 @@ class EditCounterController extends XtoolsController
         unset($ret['yearLabels']);
         unset($ret['monthLabels']);
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/month_counts');
     }
 
     /**
@@ -540,6 +540,6 @@ class EditCounterController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'timecard' => $this->editCounter->timeCard(),
-        ]);
+        ], 'user/timecard');
     }
 }

--- a/src/AppBundle/Controller/EditSummaryController.php
+++ b/src/AppBundle/Controller/EditSummaryController.php
@@ -116,8 +116,6 @@ class EditSummaryController extends XtoolsController
      */
     public function editSummariesApiAction(): JsonResponse
     {
-        $this->recordApiUsage('user/edit_summaries');
-
         // Instantiate an EditSummary, treating the past 150 edits as 'recent'.
         $editSummary = new EditSummary($this->project, $this->user, $this->namespace, $this->start, $this->end, 150);
         $editSummaryRepo = new EditSummaryRepository();
@@ -126,6 +124,6 @@ class EditSummaryController extends XtoolsController
         $editSummary->setI18nHelper($this->container->get('app.i18n_helper'));
         $editSummary->prepareData();
 
-        return $this->getFormattedApiResponse($editSummary->getData());
+        return $this->getFormattedApiResponse($editSummary->getData(), 'user/edit_summaries');
     }
 }

--- a/src/AppBundle/Controller/PagesController.php
+++ b/src/AppBundle/Controller/PagesController.php
@@ -297,8 +297,6 @@ class PagesController extends XtoolsController
      */
     public function countPagesApiAction(string $redirects = 'noredirects', string $deleted = 'all'): JsonResponse
     {
-        $this->recordApiUsage('user/pages_count');
-
         $pagesRepo = new PagesRepository();
         $pagesRepo->setContainer($this->container);
         $pages = new Pages(
@@ -318,7 +316,7 @@ class PagesController extends XtoolsController
             $counts = $counts[$this->namespace];
         }
 
-        return $this->getFormattedApiResponse(['counts' => $counts]);
+        return $this->getFormattedApiResponse(['counts' => $counts], 'user/pages_count');
     }
 
     /**
@@ -349,8 +347,6 @@ class PagesController extends XtoolsController
      */
     public function getPagesApiAction(string $redirects = 'noredirects', string $deleted = 'all'): JsonResponse
     {
-        $this->recordApiUsage('user/pages');
-
         $pagesRepo = new PagesRepository();
         $pagesRepo->setContainer($this->container);
         $pages = new Pages(
@@ -379,6 +375,6 @@ class PagesController extends XtoolsController
             $ret['continue'] = $this->offset + 1;
         }
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/pages');
     }
 }

--- a/src/AppBundle/Controller/SimpleEditCounterController.php
+++ b/src/AppBundle/Controller/SimpleEditCounterController.php
@@ -150,6 +150,6 @@ class SimpleEditCounterController extends XtoolsController
         $ret['userGroups'] = $ret['user_groups'];
         $ret['globalUserGroups'] = $ret['global_user_groups'];
 
-        return $this->getFormattedApiResponse($ret);
+        return $this->getFormattedApiResponse($ret, 'user/simple_editcount');
     }
 }

--- a/src/AppBundle/Controller/TopEditsController.php
+++ b/src/AppBundle/Controller/TopEditsController.php
@@ -209,8 +209,6 @@ class TopEditsController extends XtoolsController
      */
     public function topEditsUserApiAction(): JsonResponse
     {
-        $this->recordApiUsage('user/topedits');
-
         if (!$this->project->userHasOptedIn($this->user)) {
             return new JsonResponse(
                 [
@@ -236,6 +234,6 @@ class TopEditsController extends XtoolsController
 
         return $this->getFormattedApiResponse([
             'top_edits' => $topEdits->getTopEdits(),
-        ]);
+        ], 'user/topedits');
     }
 }

--- a/src/AppBundle/Response/EarlyJsonResponse.php
+++ b/src/AppBundle/Response/EarlyJsonResponse.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types = 1);
+
+namespace AppBundle\Response;
+
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * An EarlyJsonResponse is used to send a JsonResponse to the client, and then execute arbitrary code afterwards.
+ * This is used primarily for the XTools API, where we want to run database transactions that record usage of the API,
+ * but not hold up returning a response in the event the db transaction is slow or fails entirely.
+ * Code largely courtesy of Omn from https://stackoverflow.com/a/48352717/604142 - CC BY-SA 4.0
+ */
+class EarlyJsonResponse extends JsonResponse
+{
+    /** @var callable|null Callback to be executed after Response has been sent. */
+    protected $callbackAction = null;
+
+    /**
+     * EarlyResponse constructor.
+     * @param mixed $content
+     * @param int $status
+     * @param array $headers
+     * @param callable|null $callback
+     */
+    public function __construct($content = '', int $status = 200, array $headers = [], ?callable $callback = null)
+    {
+        $this->callbackAction = $callback;
+        parent::__construct($content, $status, $headers);
+    }
+
+    /**
+     * Set the callback function.
+     * @param callable $callback
+     */
+    public function setCallbackAction(callable $callback): void
+    {
+        $this->callbackAction = $callback;
+    }
+
+    /**
+     * Send the Response early, allowing AppKernel::terminate() to run self::callTerminateCallback().
+     * @return $this|JsonResponse
+     */
+    public function send()
+    {
+        // we don't need the hack when using fast CGI
+        if (function_exists('fastcgi_finish_request') || 'cli' === PHP_SAPI) {
+            return parent::send();
+        }
+        //prevent apache killing the process
+        ignore_user_abort(true);
+        // Check if an ob buffer exists already.
+        if (!ob_get_level()) {
+            // start the output buffer
+            ob_start();
+        }
+        // Send the content to the buffer
+        $this->sendContent();
+
+        // Flush all but the last ob buffer level
+        static::closeOutputBuffers(1, true);
+
+        // Set the content length using the last ob buffer level
+        $this->headers->set('Content-Length', ob_get_length());
+
+        // Close the Connection
+        $this->headers->set('Connection', 'close');
+
+        // This invalid header value will make Apache not delay sending the response while it is
+        // See: https://serverfault.com/questions/844526/apache-2-4-7-ignores-response-header-content-encoding-identity-instead-respect
+        $this->headers->set('Content-Encoding', 'none');
+
+        // Now that we have the headers, we can send them (which will avoid the ob buffers)
+        $this->sendHeaders();
+
+        // Flush the last ob buffer level
+        static::closeOutputBuffers(0, true);
+
+        // After we flush the OB buffer to the normal buffer, we still need to send the normal buffer to output
+        flush();
+
+        // Close session file on server side to avoid blocking other requests
+        session_write_close();
+
+        return $this;
+    }
+
+    /**
+     * Execute the callback.
+     * @return $this
+     */
+    public function callTerminateCallback()
+    {
+        if ($this->callbackAction) {
+            call_user_func($this->callbackAction);
+        }
+        return $this;
+    }
+}

--- a/src/AppKernel.php
+++ b/src/AppKernel.php
@@ -2,7 +2,10 @@
 
 declare(strict_types = 1);
 
+use AppBundle\Response\EarlyJsonResponse;
 use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Kernel;
 
 /**
@@ -86,5 +89,27 @@ class AppKernel extends Kernel
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load($this->getProjectDir().'/config/config_'.$this->getEnvironment().'.yml');
+    }
+
+    /**
+     * This called just before a process terminates.
+     * @param Request $request
+     * @param Response $response
+     */
+    public function terminate(Request $request, Response $response): void
+    {
+        ob_start();
+
+        // Run this stuff before the terminate events.
+        if ($response instanceof EarlyJsonResponse) {
+            $response->callTerminateCallback();
+        }
+
+        // Trigger the terminate events.
+        parent::terminate($request, $response);
+
+        //Optionally, we can output the buffer that will get cleaned to a file before discarding its contents
+        //file_put_contents('/tmp/process.log', ob_get_contents());
+        ob_end_clean();
     }
 }


### PR DESCRIPTION
Sometimes tools-db is slow, we've hit our max connection limit, or it's
down completely. In all cases we don't want to delay sending a response
to consumers of the API. This commit introduces EarlyJsonResponse,
courtesy of Omn from https://stackoverflow.com/a/48352717/604142.

This also adds tracking for some API responses, such as
patroller/steward stats, log counts, namespace totals, month counts and
timecard.