### PR TITLE
Make year/month count CSV exports comprehensible

### DIFF
--- a/src/AppBundle/Model/EditCounter.php
+++ b/src/AppBundle/Model/EditCounter.php
@@ -23,9 +23,6 @@ class EditCounter extends UserRights
     /** @var string[] The IDs and timestamps of first/latest edit and logged action. */
     protected $firstAndLatestActions;
 
-    /** @var int[] The total page counts. */
-    protected $pageCounts;
-
     /** @var int[] The lot totals. */
     protected $logCounts;
 

--- a/templates/editCounter/monthcounts.csv.twig
+++ b/templates/editCounter/monthcounts.csv.twig
@@ -1,6 +1,7 @@
-{{ msg('month') }},{{ msg('count') }}
-{% for nsId in ec.monthCounts.totals|keys %}
-{% for month,total in ec.monthTotals %}
-{{ month }},{{ total }}
+{{ msg('month') }},{% for nsId in ec.monthCounts.totals|keys %}
+{{ nsName(nsId, project.namespaces) }}{% if not(loop.last) %},{% endif %}
 {% endfor %}
+
+{% for month, counts in ec.monthCountsWithNamespaces %}
+{{ month }},{{ counts|join(',') }}
 {% endfor %}

--- a/templates/editCounter/yearcounts.csv.twig
+++ b/templates/editCounter/yearcounts.csv.twig
@@ -1,7 +1,7 @@
-{{ msg('namespace') }},{% for year in ec.yearCounts.yearLabels %}
-{{ year }}{% if not loop.last %},{% endif %}
+{{ msg('year') }},{% for nsId in ec.yearCounts.totals|keys %}
+{{ nsName(nsId, project.namespaces) }}{% if not loop.last %},{% endif %}
 {% endfor %}
 
-{% for nsId,namespaceData in ec.yearCounts.totals %}
-{{ nsName(nsId, project.namespaces) }},{{ namespaceData|join(',') }}
+{% for year, counts in ec.yearCountsWithNamespaces %}
+{{ year }},{{ counts|join(',') }}
 {% endfor %}


### PR DESCRIPTION
Columns are namespaces, rows are years/months.

Also removed one unused class property from EditCounter.

Bug: T236095