### PR TITLE
AutoEdits: Add 2 tools, tweak some others

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -463,6 +463,10 @@ parameters:
             link: User:DannyS712/Change_status
             regex: \[\[User:DannyS712/Change status\|Change status\.js\]\]
             namespaces: [104]
+    es.wikipedia.org:
+        Replacer:
+            tag: 'OAuth CID: 498'
+            link: Usuario:Benjavalero/Replacer
     fa.wikipedia.org:
         Typo fixer:
             label: 'ویکی‌پدیا:اشتباه‌یاب'

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -436,6 +436,10 @@ parameters:
             regex: '\(\[\[User:Enterprisey\/undo-last-edit\.js\|undo-last-edit\]\]\)'
             link: User:Enterprisey/undo-last-edit
             revert: true
+        userRightsManager:
+            regex: 'using \[\[User:MusikAnimal\/userRightsManager\|userRightsManager\]\]'
+            link: User:MusikAnimal/userRightsManager
+            namespaces: [3, 4]
         Vada:
             regex: '\(\[\[WP:Vada\]\]\)'
             link: Project:Vada

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -529,9 +529,9 @@ parameters:
             regex: 'MediaWiki_talk:Gadget-labelLister.js\|labelLister'
             link: MediaWiki talk:Gadget-labelLister.js
             namespaces: [ 0, 120 ]
-        Merge.js:
-            regex: '\[\[MediaWiki:Gadget-Merge\.js\|merge\.js\]\]'
-            link: MediaWiki talk:Gadget-Merge.js
+        Merge:
+            regex: '\[\[MediaWiki:Gadget-Merge\.js\|merge\.js\]\]|^Merged Item'
+            link: Help:Merge
         Sitelink auto-change:
             regex: 'clientsitelink-update'
             link: Help:Sitelinks

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -41,12 +41,9 @@ parameters:
             regex: 'Help:Cat-a-lot'
             link: commons:Special:MyLanguage/Help:Gadget-Cat-a-lot
             tag: Cat-a-lot
-        Commons duplicate file:
-            regex: 'COM:Duplicate\|Duplicate'
-            link: c:Commons:Duplicate
-        Commons file rename:
-            regex: 'COM:FR\|File renamed\]\]:'
-            link: c:Special:MyLanguage/Commons:File renaming
+        Commons global replace:
+            regex: 'COM:FR\|File renamed\]\]:|COM:Duplicate\|Duplicate|\(\[\[c:GR\|GR\]\]\)'
+            link: c:Special:MyLanguage/Commons:File renaming/Global replace
         Content translation:
             tag: contenttranslation
             regex: 'Created by translating the page'
@@ -325,9 +322,6 @@ parameters:
             regex: 'WP:FTCG\|FtCG'
             link: Project:FTCG
             namespaces: [6]
-        Global replace:
-            regex: '\(\[\[c:GR\|GR\]\]\) '
-            link: commons:Commons:File renaming/Global replace
         Heading editor:
             regex: '\[\[User:The Evil IP address\/hdedit\|script\]\]'
             link: User:The Evil IP address/hdedit

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -524,7 +524,7 @@ parameters:
             link: MediaWiki talk:Gadget-labelLister.js
             namespaces: [ 0, 120 ]
         Merge:
-            regex: '\[\[MediaWiki:Gadget-Merge\.js\|merge\.js\]\]|^Merged Item'
+            regex: '\[\[MediaWiki:Gadget-Merge\.js\|merge\.js\]\]|\/\* wbmergeitems'
             link: Help:Merge
         Sitelink auto-change:
             regex: 'clientsitelink-update'

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -262,6 +262,9 @@ parameters:
             regex: '^Reverting possible (vandalism|test edit).*by.*\(Bot|BOT( EDIT)?\)$|^BOT (- )?(Reverted edits? by|rv)|^vandalism from \[\[.*?\(\d+\) - reverted'
             link: Project:Bots
             revert: true
+        Capricorn:
+            regex: '\(\[\[User:Kephir\/gadgets\/sagittarius\||\(\[\[User:Sam Sailor\/Scripts\/Sagittarius\+\||\[\[User:Wugapodes\/Capricorn\|'
+            link: User:Wugapodes/Capricorn
         Checklinks:
             regex: 'using \[\[w:WP:CHECKLINKS'
             link: Project:CHECKLINKS
@@ -382,9 +385,6 @@ parameters:
         revdel:
             regex: 'using \[\[User:Primefac\/revdel|User:Enterprisey\/cv-revdel\|'
             link: User:Enterprisey/cv-revdel
-        Sagittarius:
-            regex: '\(\[\[User:Kephir\/gadgets\/sagittarius\||\(\[\[User:Sam Sailor\/Scripts\/Sagittarius\+\|'
-            link: User:Sam Sailor/Scripts/Sagittarius+
         Script Installer:
             regex: '\[\[User:Equazcion\/ScriptInstaller\|Script Installer|\(\[\[User:Enterprisey\/script-installer\|script-installer\]\]\)'
             link: User:Enterprisey/script-installer

--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -355,8 +355,9 @@ parameters:
             namespaces: [0, 2, 118]
         Page curation:
             regex: 'using \[\[Wikipedia:Page Curation\|Page Curation'
+            tag: pagetriage
             link: w:en:Wikipedia:Page_Curation/Help
-            namespaces: [0, 1, 2, 3]
+            namespaces: [0, 1, 2, 3, 4]
         Page swap:
             regex: '\/pageswap\|pageswap\]\]'
             link: WP:PAGESWAP


### PR DESCRIPTION
Commit 1: Update page curation with namespace 4 and pagetriage tag
Commit 2: Add userRightsManager for enwiki, in namespaces 3 and 4
Commit 3: Add Replacer tool for eswiki
Commit 4: Expand wikidata merge tool to include Special:MergeItems
Commit 5: Combine different commons global replace tools into 1 global rule
Commit 6: Rename Sagittarius to Capricorn, update regex and link

Bug: T237217
Bug: T237174
Bug: T237076
Bug: T231709
Bug: T236719
Bug: T237458