### PR TITLE
Remove asset changes test from Scrutinizer config

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -15,9 +15,6 @@ build:
     tests:
         override:
             -
-                # Make sure nothing's changed in Git, which would indicate asset changes were not committed.
-                command: git status | grep 'nothing to commit, working tree clean'
-            -
                 command: ./vendor/bin/parallel-lint --exclude vendor .
             -
                 command: ./vendor/bin/phpcs -s . --ignore=/home/scrutinizer/build/node_modules


### PR DESCRIPTION
This stopped working for unknown reasons some months ago. It always
fails. This is not a critical test, so for now we'll just remove it.