### PR TITLE
AutoEdit: Fix regex for en.wiktionary script

### DIFF
--- a/config/semi_automated.yml
+++ b/config/semi_automated.yml
@@ -493,7 +493,7 @@ parameters:
             namespaces: [104]
     en.wiktionary.org:
         TranslationAdder:
-            regex: '\[\[WT:EDIT'
+            regex: '\[\[WT:EDIT\|Assisted'
             link: MediaWiki talk:Gadget-TranslationAdder.js          
     es.wikipedia.org:
         DisamAssist:


### PR DESCRIPTION
Follow-up: 17eb31c; expands the regex to make it more specific and avoid false positives

Bug: T250615