### PR TITLE
ArticleInfo: show warning when usernames are missing

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -148,6 +148,7 @@
 	"error-server-message": "The server said: $1",
 	"error-service-overload": "XTools is currently overloaded servicing other requests. Please try again in a few minutes.",
 	"error-title": "A fatal error has occurred within XTools. This has been automatically reported, but feel free to file a task on $1 (requires a Wikimedia account).",
+	"error-usernames-missing": "No usernames could be retrieved. As a result, some data may be inaccurate or misleading.",
 	"events": "Events",
 	"exclusion-pattern": "Don't include pages with titles that match the given pattern.",
 	"executed": "Executed in $1 {{PLURAL:$2|second|seconds}}.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -165,6 +165,7 @@
 	"error-server-message": "Error message. $1 is the message given by the server.",
 	"error-service-overload": "Error message shown when too many people are using XTools.",
 	"error-title": "Title for the error page. $1 is a link to report the error on Phabricator.",
+	"error-usernames-missing": "Warning shown when XTools was unable to retrieve usernames from the database.",
 	"events": "Events that have a log entry\n{{Identical|Event}}",
 	"exclusion-pattern": "Description for the 'Exclusion pattern' field in the Largest Pages tool.",
 	"executed": "Execution time. $1 is the formatted number of seconds, and $2 is the unformatted number for use with PLURAL.",

--- a/src/AppBundle/Controller/ArticleInfoController.php
+++ b/src/AppBundle/Controller/ArticleInfoController.php
@@ -145,6 +145,11 @@ class ArticleInfoController extends XtoolsController
             $this->addFlashMessage('warning', 'old-page-notice');
         }
 
+        // When all username info has been hidden (see T303724).
+        if (0 === $this->articleInfo->getNumEditors()) {
+            $this->addFlashMessage('warning', 'error-usernames-missing');
+        }
+
         $ret = [
             'xtPage' => 'ArticleInfo',
             'xtTitle' => $this->page->getTitle(),
@@ -153,7 +158,7 @@ class ArticleInfoController extends XtoolsController
             'botlimit' => $this->request->query->get('botlimit', 10),
             'pageviewsOffset' => 60,
             'ai' => $this->articleInfo,
-            'showAuthorship' => Authorship::isSupportedPage($this->page),
+            'showAuthorship' => Authorship::isSupportedPage($this->page) && $this->articleInfo->getNumEditors() > 0,
         ];
 
         // Output the relevant format template.

--- a/src/AppBundle/Model/ArticleInfo.php
+++ b/src/AppBundle/Model/ArticleInfo.php
@@ -298,7 +298,12 @@ class ArticleInfo extends ArticleInfoApi
      */
     public function editsPerEditor(): float
     {
-        return round($this->getNumRevisionsProcessed() / count($this->editors), 1);
+        if (count($this->editors) > 0) {
+            return round($this->getNumRevisionsProcessed() / count($this->editors), 1);
+        }
+
+        // To prevent division by zero error; can happen if all usernames are removed (see T303724).
+        return 0;
     }
 
     /**

--- a/src/AppBundle/Model/Page.php
+++ b/src/AppBundle/Model/Page.php
@@ -8,6 +8,7 @@ declare(strict_types = 1);
 namespace AppBundle\Model;
 
 use DateTime;
+use Doctrine\DBAL\Driver\PDOStatement;
 
 /**
  * A Page is a single wiki page in one project.
@@ -337,13 +338,13 @@ class Page extends Model
      * Get the statement for a single revision, so that you can iterate row by row.
      * @see PageRepository::getRevisionsStmt()
      * @param User|null $user Specify to get only revisions by the given user.
-     * @param int $limit Max number of revisions to process.
-     * @param int $numRevisions Number of revisions, if known. This is used solely to determine the
+     * @param ?int $limit Max number of revisions to process.
+     * @param ?int $numRevisions Number of revisions, if known. This is used solely to determine the
      *   OFFSET if we are given a $limit. If $limit is set and $numRevisions is not set, a
      *   separate query is ran to get the nuber of revisions.
      * @param false|int $start
      * @param false|int $end
-     * @return \Doctrine\DBAL\Driver\PDOStatement
+     * @return PDOStatement
      */
     public function getRevisionsStmt(
         ?User $user = null,
@@ -351,7 +352,7 @@ class Page extends Model
         ?int $numRevisions = null,
         $start = false,
         $end = false
-    ): \Doctrine\DBAL\Driver\PDOStatement {
+    ): PDOStatement {
         // If we have a limit, we need to know the total number of revisions so that PageRepo
         // will properly set the OFFSET. See PageRepository::getRevisionsStmt() for more info.
         if (isset($limit) && null === $numRevisions) {

--- a/src/AppBundle/Repository/PageRepository.php
+++ b/src/AppBundle/Repository/PageRepository.php
@@ -121,8 +121,8 @@ class PageRepository extends Repository
      * Get the statement for a single revision, so that you can iterate row by row.
      * @param Page $page The page.
      * @param User|null $user Specify to get only revisions by the given user.
-     * @param int $limit Max number of revisions to process.
-     * @param int $numRevisions Number of revisions, if known. This is used solely to determine the
+     * @param ?int $limit Max number of revisions to process.
+     * @param ?int $numRevisions Number of revisions, if known. This is used solely to determine the
      *   OFFSET if we are given a $limit (see below). If $limit is set and $numRevisions is not set,
      *   a separate query is ran to get the number of revisions.
      * @param false|int $start
@@ -165,7 +165,7 @@ class PageRepository extends Repository
                         comment_text AS `comment`,
                         revs.rev_sha1 AS sha
                     FROM $revTable AS revs
-                    JOIN $actorTable ON revs.rev_actor = actor_id
+                    LEFT JOIN $actorTable ON revs.rev_actor = actor_id
                     LEFT JOIN $revTable AS parentrevs ON (revs.rev_parent_id = parentrevs.rev_id)
                     LEFT OUTER JOIN $commentTable ON comment_id = revs.rev_comment_id
                     WHERE $userClause revs.rev_page = :pageid $dateConditions

--- a/templates/articleInfo/result.html.twig
+++ b/templates/articleInfo/result.html.twig
@@ -55,7 +55,10 @@
             {% if showAuthorship %}
                 {% set sections = sections|merge(['tool-authorship']) %}
             {% endif %}
-            {% set sections = sections|merge(['top-editors', 'year-counts', 'month-counts']) %}
+            {% if ai.numEditors > 0 %}
+                {% set sections = sections|merge(['top-editors']) %}
+            {% endif %}
+            {% set sections = sections|merge(['year-counts', 'month-counts']) %}
             {% if ai.automatedCount > 0 %}
                 {% set sections = sections|merge(['auto-edits']) %}
             {% endif %}
@@ -454,111 +457,36 @@
         {% endif %}
 
         {# ======================== TOP EDITORS ======================== #}
-        {% set content %}
-            <div class="top-editors-charts clearfix">
-                <div class="pull-left">
-                    <div class="chart-title">{{ msg('top-ten-by-edits')|ucfirst }}</div>
-                    {{ chart.pie_chart('top_by_edits', ai.topTenEditorsByEdits) }}
-                </div>
-                {% if ai.maxAddition is not null %}
+        {% if ai.numEditors > 0 %}
+            {% set content %}
+                <div class="top-editors-charts clearfix">
                     <div class="pull-left">
-                        <div class="chart-title">
-                            {{ msg('top-ten-by-text')|ucfirst }}
-                            <span class="text-muted">({{ msg('approximate')|lower }})</span>
-                        </div>
-                        {{ chart.pie_chart('top_by_added', ai.topTenEditorsByAdded) }}
+                        <div class="chart-title">{{ msg('top-ten-by-edits')|ucfirst }}</div>
+                        {{ chart.pie_chart('top_by_edits', ai.topTenEditorsByEdits) }}
                     </div>
-                {% endif %}
-            </div>
-            <table class="table table-bordered table-hover table-striped top-editors-table">
-                <thead><tr>
-                    {% for key in ['rank', 'username', 'links', 'edits', 'minor-edits', 'minor-edits-percentage', 'first-edit', 'latest-edit', 'average-time-bw-edits', 'added-bytes'] %}
-                        <th>
-                            <span{% if key != "links" %} class="sort-link sort-link--{{ key }}" data-column="{{ key }}"{% endif %}>
-                                {% if key == 'average-time-bw-edits' %}
-                                    atbe<sup>1</sup>
-                                {% else %}
-                                    {{ msg(key)|ucfirst }}
-                                {% endif %}
-                                {% if key == 'added-bytes' %}
-                                    <sup class="rm-inline-margin-left">2</sup>
-                                {% endif %}
-                                {% if key != "links" %}<span class="glyphicon glyphicon-sort"></span>{% endif %}
-                            </span>
-                        </th>
-                    {% endfor %}
-                </tr></thead>
-                <tbody>
-                {% set counter = 0 %}
-                {% set editSum = 0 %}
-                {% for editor in ai.humans(editorlimit) %}
-                    {% set stats = ai.editors[editor] %}
-                    {% set counter = counter + 1 %}
-                    {% set editSum = editSum + stats.all %}
-                    <tr>
-                        <td class="sort-entry--rank" data-value="{{ counter }}">{{ counter|num_format }}</td>
-                        <td class="sort-entry--username" data-value="{{ editor }}">
-                            {{ wiki.userLink(editor, project) }}
-                        </td>
-                        <td>
-                            {% if enabled('TopEdits') %}
-                                <a href="{{ path('TopEditsResultPage', { 'project': project.domain, 'username': editor, 'namespace': page.namespace, 'page': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
-                            {% endif %}
-                            &middot;
-                            {% if enabled('EditCounter') %}
-                                <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': editor }) }}">{{ msg('tool-editcounter') }}</a>
-                            {% endif %}
-                        </td>
-                        <td class="sort-entry--edits" data-value="{{ stats.all }}">
-                            {{ stats.all|num_format }}
-                        </td>
-                        <td class="sort-entry--minor-edits" data-value="{{ stats.minor }}">{{ stats.minor|num_format }}</td>
-                        {% set userMinorPercent = stats.minor|percent_format(stats.all) %}
-                        <td class="sort-entry--minor-percentage" data-value="{{ userMinorPercent }}">{{ userMinorPercent }}</td>
-                        <td class="sort-entry--first-edit" data-value="{{ stats.firstId }}">
-                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.firstId, project, stats.first|date_format) }}
-                        </td>
-                        <td class="sort-entry--latest-edit" data-value="{{ stats.lastId }}">
-                            {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.lastId, project, stats.last|date_format) }}
-                        </td>
-                        <td class="sort-entry--average-time-bw-edits" data-value="{{ stats.atbe }}">
-                            {{ stats.atbe|num_format() }}
-                        </td>
-                        <td class="sort-entry--added-bytes" data-value="{{ stats.added }}">
-                            {{ stats.added|num_format }}
-                        </td>
-                    </tr>
-                {% endfor %}
-                </tbody>
-                {% set otherEditors = ai.numEditors - ai.numBots - counter %}
-                {% if otherEditors > 0 %}
-                    <tfoot><tr class="show-more-row">
-                        <td></td>
-                        <td>
-                            {% set expandUrl = path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'editorlimit': editorlimit * 10})) %}
-                            <a href="{{ expandUrl }}">
-                                {{ otherEditors|num_format }} {{ msg('num-others', [otherEditors]) }}
-                            </a>
-                        </td>
-                        <td></td>
-                        <td>{{ (ai.numRevisionsProcessed - editSum)|num_format }}</td>
-                        <td colspan=6></td>
-                    </tr></tfoot>
-                {% endif %}
-            </table>
-            <div class="footnotes">
-                <sup>1</sup> {{ msg('average-time-bw-edits') }}
-                <br/><sup>2</sup> {{ msg('text-added-description') }}
-            </div>
-
-            {% if ai.bots is not empty %}
-                <h4>{{ msg('bot-list') }}</h4>
-                <table class="table table-bordered table-hover table-striped">
+                    {% if ai.maxAddition is not null %}
+                        <div class="pull-left">
+                            <div class="chart-title">
+                                {{ msg('top-ten-by-text')|ucfirst }}
+                                <span class="text-muted">({{ msg('approximate')|lower }})</span>
+                            </div>
+                            {{ chart.pie_chart('top_by_added', ai.topTenEditorsByAdded) }}
+                        </div>
+                    {% endif %}
+                </div>
+                <table class="table table-bordered table-hover table-striped top-editors-table">
                     <thead><tr>
-                        {% for key in ['rank', 'bot', 'links', 'edits'] %}
+                        {% for key in ['rank', 'username', 'links', 'edits', 'minor-edits', 'minor-edits-percentage', 'first-edit', 'latest-edit', 'average-time-bw-edits', 'added-bytes'] %}
                             <th>
                                 <span{% if key != "links" %} class="sort-link sort-link--{{ key }}" data-column="{{ key }}"{% endif %}>
-                                    {{ msg(key)|ucfirst }}
+                                    {% if key == 'average-time-bw-edits' %}
+                                        atbe<sup>1</sup>
+                                    {% else %}
+                                        {{ msg(key)|ucfirst }}
+                                    {% endif %}
+                                    {% if key == 'added-bytes' %}
+                                        <sup class="rm-inline-margin-left">2</sup>
+                                    {% endif %}
                                     {% if key != "links" %}<span class="glyphicon glyphicon-sort"></span>{% endif %}
                                 </span>
                             </th>
@@ -566,55 +494,132 @@
                     </tr></thead>
                     <tbody>
                     {% set counter = 0 %}
-                    {% for bot, botData in ai.bots|slice(0, botlimit) %}
+                    {% set editSum = 0 %}
+                    {% for editor in ai.humans(editorlimit) %}
+                        {% set stats = ai.editors[editor] %}
                         {% set counter = counter + 1 %}
+                        {% set editSum = editSum + stats.all %}
                         <tr>
                             <td class="sort-entry--rank" data-value="{{ counter }}">{{ counter|num_format }}</td>
-                            <td class="sort-entry--bot" data-value="{{ bot }}">
-                                {{ wiki.userLink(bot, project) }}
-                                {% if not botData.current %}
-                                    <i>
-                                        (<a href="{{ path('EditCounterRightsChanges', {project: project.domain, username: bot}) }}">{{ msg('former-bot') }}</a>)
-                                    </i>
-                                {% endif %}
+                            <td class="sort-entry--username" data-value="{{ editor }}">
+                                {{ wiki.userLink(editor, project) }}
                             </td>
                             <td>
                                 {% if enabled('TopEdits') %}
-                                    <a href="{{ path('TopEditsResultPage', { 'project': project.domain, 'username': bot, 'namespace': page.namespace, 'page': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
+                                    <a href="{{ path('TopEditsResultPage', { 'project': project.domain, 'username': editor, 'namespace': page.namespace, 'page': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
                                 {% endif %}
                                 &middot;
                                 {% if enabled('EditCounter') %}
-                                    <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': bot }) }}">{{ msg('tool-editcounter') }}</a>
+                                    <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': editor }) }}">{{ msg('tool-editcounter') }}</a>
                                 {% endif %}
                             </td>
-                            <td class="sort-entry--edits" data-value="{{ botData.count }}">{{ botData.count|num_format }}</td>
+                            <td class="sort-entry--edits" data-value="{{ stats.all }}">
+                                {{ stats.all|num_format }}
+                            </td>
+                            <td class="sort-entry--minor-edits" data-value="{{ stats.minor }}">{{ stats.minor|num_format }}</td>
+                            {% set userMinorPercent = stats.minor|percent_format(stats.all) %}
+                            <td class="sort-entry--minor-percentage" data-value="{{ userMinorPercent }}">{{ userMinorPercent }}</td>
+                            <td class="sort-entry--first-edit" data-value="{{ stats.firstId }}">
+                                {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.firstId, project, stats.first|date_format) }}
+                            </td>
+                            <td class="sort-entry--latest-edit" data-value="{{ stats.lastId }}">
+                                {{ wiki.pageLinkRaw('Special:Diff/' ~ stats.lastId, project, stats.last|date_format) }}
+                            </td>
+                            <td class="sort-entry--average-time-bw-edits" data-value="{{ stats.atbe }}">
+                                {{ stats.atbe|num_format() }}
+                            </td>
+                            <td class="sort-entry--added-bytes" data-value="{{ stats.added }}">
+                                {{ stats.added|num_format }}
+                            </td>
                         </tr>
                     {% endfor %}
                     </tbody>
-                    {% if counter < ai.numBots %}
+                    {% set otherEditors = ai.numEditors - ai.numBots - counter %}
+                    {% if otherEditors > 0 %}
                         <tfoot><tr class="show-more-row">
                             <td></td>
                             <td>
-                                {% set expandUrl = path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'botlimit': botlimit * 10})) %}
-                                {% set otherBots = ai.numBots - counter %}
+                                {% set expandUrl = path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'editorlimit': editorlimit * 10})) %}
                                 <a href="{{ expandUrl }}">
-                                    {{ otherBots|num_format }} {{ msg('num-others', [otherBots]) }}
+                                    {{ otherEditors|num_format }} {{ msg('num-others', [otherEditors]) }}
                                 </a>
                             </td>
-                            <td colspan=8></td>
+                            <td></td>
+                            <td>{{ (ai.numRevisionsProcessed - editSum)|num_format }}</td>
+                            <td colspan=6></td>
                         </tr></tfoot>
                     {% endif %}
                 </table>
-            {% endif %}
+                <div class="footnotes">
+                    <sup>1</sup> {{ msg('average-time-bw-edits') }}
+                    <br/><sup>2</sup> {{ msg('text-added-description') }}
+                </div>
 
-            <div class="text-muted">
-                {{ msg('all-approximate') }}
-            </div>
-        {% endset %}
-        {% set downloadLink %}
-            {{ layout.downloadLink('ArticleInfoResult', {project:project.domain, page:page.title, start:ai.startDate, end:ai.endDate}, ['wikitext'], 'PageApiTopEditors') }}
-        {% endset %}
-        {{ layout.content_block('top-editors', content, ['top-editors-desc', downloadLink]) }}
+                {% if ai.bots is not empty %}
+                    <h4>{{ msg('bot-list') }}</h4>
+                    <table class="table table-bordered table-hover table-striped">
+                        <thead><tr>
+                            {% for key in ['rank', 'bot', 'links', 'edits'] %}
+                                <th>
+                                    <span{% if key != "links" %} class="sort-link sort-link--{{ key }}" data-column="{{ key }}"{% endif %}>
+                                        {{ msg(key)|ucfirst }}
+                                        {% if key != "links" %}<span class="glyphicon glyphicon-sort"></span>{% endif %}
+                                    </span>
+                                </th>
+                            {% endfor %}
+                        </tr></thead>
+                        <tbody>
+                        {% set counter = 0 %}
+                        {% for bot, botData in ai.bots|slice(0, botlimit) %}
+                            {% set counter = counter + 1 %}
+                            <tr>
+                                <td class="sort-entry--rank" data-value="{{ counter }}">{{ counter|num_format }}</td>
+                                <td class="sort-entry--bot" data-value="{{ bot }}">
+                                    {{ wiki.userLink(bot, project) }}
+                                    {% if not botData.current %}
+                                        <i>
+                                            (<a href="{{ path('EditCounterRightsChanges', {project: project.domain, username: bot}) }}">{{ msg('former-bot') }}</a>)
+                                        </i>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {% if enabled('TopEdits') %}
+                                        <a href="{{ path('TopEditsResultPage', { 'project': project.domain, 'username': bot, 'namespace': page.namespace, 'page': page.titleWithoutNamespace }) }}">{{ msg('tool-topedits') }}</a>
+                                    {% endif %}
+                                    &middot;
+                                    {% if enabled('EditCounter') %}
+                                        <a href="{{ path('EditCounterResult', { 'project': project.domain, 'username': bot }) }}">{{ msg('tool-editcounter') }}</a>
+                                    {% endif %}
+                                </td>
+                                <td class="sort-entry--edits" data-value="{{ botData.count }}">{{ botData.count|num_format }}</td>
+                            </tr>
+                        {% endfor %}
+                        </tbody>
+                        {% if counter < ai.numBots %}
+                            <tfoot><tr class="show-more-row">
+                                <td></td>
+                                <td>
+                                    {% set expandUrl = path(app.request.attributes.get('_route'), app.request.get('_route_params')|merge({'botlimit': botlimit * 10})) %}
+                                    {% set otherBots = ai.numBots - counter %}
+                                    <a href="{{ expandUrl }}">
+                                        {{ otherBots|num_format }} {{ msg('num-others', [otherBots]) }}
+                                    </a>
+                                </td>
+                                <td colspan=8></td>
+                            </tr></tfoot>
+                        {% endif %}
+                    </table>
+                {% endif %}
+
+                <div class="text-muted">
+                    {{ msg('all-approximate') }}
+                </div>
+            {% endset %}
+            {% set downloadLink %}
+                {{ layout.downloadLink('ArticleInfoResult', {project:project.domain, page:page.title, start:ai.startDate, end:ai.endDate}, ['wikitext'], 'PageApiTopEditors') }}
+            {% endset %}
+            {{ layout.content_block('top-editors', content, ['top-editors-desc', downloadLink]) }}
+        {% endif %}
 
         {# ======================== YEAR COUNTS ======================== #}
         {% set content %}


### PR DESCRIPTION
If usernames are missing, some calculations can be misleading. This
commit shows a warning when usernames could not be retrieved, and hides
the relevant sections (Top Editors, Authorship).

Bug: T303724