### PR TITLE
ArticleInfo: fix bot data when revs processed is less than total revs

### DIFF
--- a/src/AppBundle/Model/Page.php
+++ b/src/AppBundle/Model/Page.php
@@ -274,7 +274,7 @@ class Page extends Model
 
     /**
      * Get the number of revisions the page has.
-     * @param User $user Optionally limit to those of this user.
+     * @param ?User $user Optionally limit to those of this user.
      * @param false|int $start
      * @param false|int $end
      * @return int

--- a/templates/articleInfo/result.html.twig
+++ b/templates/articleInfo/result.html.twig
@@ -105,7 +105,7 @@
                         <td>
                             {{ ai.numRevisions|num_format }}
                             {% if ai.tooManyRevisions %}
-                                ({{ msg('num-revisions-processed', [ai.numRevisionsProcessed]) }})
+                                ({{ msg('num-revisions-processed', [ai.numRevisionsProcessed|num_format]) }})
                             {% endif %}
                         </td>
                     </tr>
@@ -115,7 +115,7 @@
                         </td>
                         <td>{{ ai.numEditors|num_format }}</td>
                     </tr>
-                    {% if not (ai.hasDateRange) and ai.assessments and not (page.isMainPage) %}
+                    {% if not (ai.hasDateRange) and ai.assessments and not(page.isMainPage) %}
                         <tr>
                             <td>
                                 <a class="rm-inline-margin" href="#assessments">{{ msg('assessment') }}</a>


### PR DESCRIPTION
This commit also slightly improves the performance of the query
by making use of the specialized actor_revision view.

Also add number formatting to the "N revision processed" figure in the
UI.

Bug: T253464