### PR TITLE
i18n: Use number format also in pageviews offset

### DIFF
--- a/templates/articleInfo/api.html.twig
+++ b/templates/articleInfo/api.html.twig
@@ -15,7 +15,7 @@
 {{ data.watchers|num_format }} {{ msg('num-watchers', [data.watchers]) }}{{ msg('comma-character') }}
 {% endif %}
 {%- if data.pageviews is defined -%}
-<a target="_blank" href="https://pageviews.toolforge.org/?project={{ project.domain }}&amp;pages={{ page.title|e('url') }}&amp;range=latest-30">{{ data.pageviews|num_format }} {{ msg('num-pageviews', [data.pageviews]) }}</a> ({{ data.pageviews_offset }} {{ msg('num-days', [data.pageviews_offset]) }}){% endif -%}
+<a target="_blank" href="https://pageviews.toolforge.org/?project={{ project.domain }}&amp;pages={{ page.title|e('url') }}&amp;range=latest-30">{{ data.pageviews|num_format }} {{ msg('num-pageviews', [data.pageviews]) }}</a> ({{ data.pageviews_offset|num_format }} {{ msg('num-days', [data.pageviews_offset]) }}){% endif -%}
 {% if data.error is not defined and data.author is not empty -%}
     {{ msg('comma-character') }}
     {{ msg('created-by')|lower }}: {{ wiki.userLink(data.author, project) }}


### PR DESCRIPTION
Number format provides digits suitable for specific locales also in addition to addition of thousand separators so let's use it here also.

For example, https://xtools.wmflabs.org/api/page/articleinfo/fa.wikipedia.org/تهران?format=html&uselang=fa there is `30 روز` and this change should turn it `۳۰ روز` which will be correct for Persian.