### PR TITLE
Repository: introduce a BadGatewayException for upstream errors

### DIFF
--- a/config/packages/prod/monolog.yaml
+++ b/config/packages/prod/monolog.yaml
@@ -40,6 +40,7 @@ monolog:
         symfony_mailer:
             type: symfony_mailer
             level: critical
+            # excluded_http_codes: [502] # Re-enable after a round of testing in prod
             from_email: '%env(MAILER_FROM_EMAIL)%'
             to_email: '%env(MAILER_TO_EMAIL)%'
             subject: '[XTools] Fatal error: %%message%%'

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -32,6 +32,7 @@
 	"all-quotes": "All quotes",
 	"api": "API",
 	"api-error": "Error querying $1",
+	"api-error-wikimedia": "There was an error connecting to the Wikimedia API. Try refreshing this page or try again later.",
 	"approve": "Approve",
 	"approximate": "Approximate",
 	"article": "Article",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -51,6 +51,7 @@
 	"all-quotes": "Label for the button to show all quotes in the Bash Quote tool.",
 	"api": "{{Optional}}\nText for link to the API documentation.\n{{Identical|API}}",
 	"api-error": "Generic error message for when something went wrong while querying an API. $1 is the name of the API. This message is followed by the error returned by the API.\n\nFor example: Latest global edits API: <code>timeout</code>",
+	"api-error-wikimedia": "Error shown when the Wikimedia servers are down.",
 	"approve": "Name of a MediaWiki log action, used as header of a row in the table of log action counts for a user.\n{{Identical|Approve}}",
 	"approximate": "Indicate the values are possibly inaccurate.\n{{Identical|Approximate}}",
 	"article": "Label for a wiki page in the main namespace.\n{{Identical|Article}}",

--- a/src/Exception/BadGatewayException.php
+++ b/src/Exception/BadGatewayException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace App\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Throwable;
+
+/**
+ * A BadGatewayException is for custom handling of upstream errors that are beyond the control of
+ * XTools maintainers. These errors (502s) are not logged by Monolog and hence no error email is sent out.
+ */
+class BadGatewayException extends HttpException
+{
+    public function __construct(string $msgKey, Throwable $e)
+    {
+        parent::__construct(Response::HTTP_BAD_GATEWAY, $msgKey, $e);
+    }
+}

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -24,9 +24,12 @@
 
         {% if msgExists(message, [exception.code]) %}
             <p><strong>{{ msg(message, [exception.code]) }}</strong></p>
-        {% elseif 999 == exception.code %}
-            {# This is a server-build message ready to be display that can safely use raw() #}
+        {% elseif exception.code == 999 %}
+            {# This is a server-built message ready to be displayed that can safely use raw() #}
             <p>{{ message|raw }}</p>
+        {% elseif status_code == 502 %}
+            {# We ignore 502s as we can't fix them, so there's no need to add a link to report it as a bug. #}
+            <p>{{ message }}</p>
         {% else %}
             {% set phabLink %}
                 <a target="_blank" href="https://phabricator.wikimedia.org/maniphest/task/create/?title=PLEASE REPLACE WITH A DESCRIPTION OF THE ERROR&amp;priority=75&amp;projects=XTools&amp;description=```{{ attribute(exception, 'file') }}: {{ attribute(exception, 'line') }} - {{ message }}```%0A%0AURL: {{app.request.uri}}%0A%0APlease provide any further details here%0A%0AXTools version: {{ version }}-{{ shortHash() }}">Phabricator</a>


### PR DESCRIPTION
This shows the error page as normal, but without a link to report it as a bug since it's outside the control of XTools maintainers.

In a future commit, we will exclude all 502s from Monolog emails.