### PR TITLE
ArticleInfo: add bot data and automated edits API endpoints

### DIFF
--- a/src/Controller/ArticleInfoController.php
+++ b/src/Controller/ArticleInfoController.php
@@ -379,4 +379,68 @@ class ArticleInfoController extends XtoolsController
             'top_editors' => $topEditors,
         ]);
     }
+
+    /**
+     * Get data about bots that have edited a page.
+     * @Route(
+     *     "/api/page/bot_data/{project}/{page}/{start}/{end}", name="PageApiBotData",
+     *     requirements={
+     *         "page"="(.+?)(?!\/(?:|\d{4}-\d{2}-\d{2})(?:\/(|\d{4}-\d{2}-\d{2}))?)?$",
+     *         "start"="|\d{4}-\d{2}-\d{2}",
+     *         "end"="|\d{4}-\d{2}-\d{2}",
+     *     },
+     *     defaults={
+     *         "start"=false,
+     *         "end"=false,
+     *     }
+     * )
+     * @param ArticleInfoRepository $articleInfoRepo
+     * @param AutomatedEditsHelper $autoEditsHelper
+     * @return JsonResponse
+     * @codeCoverageIgnore
+     */
+    public function botDataApiAction(
+        ArticleInfoRepository $articleInfoRepo,
+        AutomatedEditsHelper $autoEditsHelper
+    ): JsonResponse {
+        $this->recordApiUsage('page/bot_data');
+
+        $this->setupArticleInfo($articleInfoRepo, $autoEditsHelper);
+        $bots = $this->articleInfo->getBots();
+
+        return $this->getFormattedApiResponse([
+            'bots' => $bots,
+        ]);
+    }
+
+    /**
+     * Get counts of (semi-)automated tools that were used to edit the page.
+     * @Route(
+     *     "/api/page/automated_edits/{project}/{page}/{start}/{end}", name="PageApiAutoEdits",
+     *     requirements={
+     *         "page"="(.+?)(?!\/(?:|\d{4}-\d{2}-\d{2})(?:\/(|\d{4}-\d{2}-\d{2}))?)?$",
+     *         "start"="|\d{4}-\d{2}-\d{2}",
+     *         "end"="|\d{4}-\d{2}-\d{2}",
+     *     },
+     *     defaults={
+     *         "start"=false,
+     *         "end"=false,
+     *     }
+     * )
+     * @param ArticleInfoRepository $articleInfoRepo
+     * @param AutomatedEditsHelper $autoEditsHelper
+     * @return JsonResponse
+     * @codeCoverageIgnore
+     */
+    public function getAutoEdits(
+        ArticleInfoRepository $articleInfoRepo,
+        AutomatedEditsHelper $autoEditsHelper
+    ): JsonResponse {
+        $this->recordApiUsage('page/auto_edits');
+
+        $this->setupArticleInfo($articleInfoRepo, $autoEditsHelper);
+        return $this->getFormattedApiResponse([
+            'auto_edits' => $this->articleInfo->getAutoEditsCounts(),
+        ]);
+    }
 }

--- a/src/Model/ArticleInfoApi.php
+++ b/src/Model/ArticleInfoApi.php
@@ -318,6 +318,7 @@ class ArticleInfoApi extends Model
             $data = array_merge($data, [
                 'revisions' => (int) $info['num_edits'],
                 'editors' => (int) $info['num_editors'],
+                'ip_editors' => (int) $info['num_ip_editors'],
                 'minor_edits' => (int) $info['minor_edits'],
                 'author' => $info['author'],
                 'author_editcount' => null === $info['author_editcount'] ? null : (int) $info['author_editcount'],
@@ -489,5 +490,14 @@ class ArticleInfoApi extends Model
     public function getNumBots(): int
     {
         return count($this->getBots());
+    }
+
+    /**
+     * Get counts of (semi-)automated tools used to edit the page.
+     * @return array
+     */
+    public function getAutoEditsCounts(): array
+    {
+        return $this->repository->getAutoEditsCounts($this->page, $this->start, $this->end);
     }
 }

--- a/src/Repository/AutoEditsRepository.php
+++ b/src/Repository/AutoEditsRepository.php
@@ -526,7 +526,7 @@ class AutoEditsRepository extends UserRepository
      * @param string[] $values Values as defined in the AutoEdits config.
      * @return string[] [Equality clause, JOIN clause]
      */
-    private function getInnerAutomatedCountsSql(Project $project, string $toolName, array $values): array
+    protected function getInnerAutomatedCountsSql(Project $project, string $toolName, array $values): array
     {
         $conn = $this->getProjectsConnection($project);
         $commentJoin = '';

--- a/tests/Controller/ArticleInfoControllerTest.php
+++ b/tests/Controller/ArticleInfoControllerTest.php
@@ -55,8 +55,8 @@ class ArticleInfoControllerTest extends ControllerTestAdapter
 
         static::assertEquals(
             [
-                'project', 'page', 'watchers', 'pageviews', 'pageviews_offset',  'revisions',
-                'editors', 'minor_edits', 'author', 'author_editcount', 'created_at',  'created_rev_id',
+                'project', 'page', 'watchers', 'pageviews', 'pageviews_offset',  'revisions', 'editors',
+                'ip_editors', 'minor_edits', 'author', 'author_editcount', 'created_at',  'created_rev_id',
                 'modified_at', 'secs_since_last_edit', 'last_edit_id', 'assessment', 'elapsed_time',
             ],
             array_keys($data)
@@ -99,6 +99,8 @@ class ArticleInfoControllerTest extends ControllerTestAdapter
             '/api/page/links/en.wikipedia/Ravine_du_Sud',
             '/api/page/top_editors/en.wikipedia/Ravine_du_Sud',
             '/api/page/top_editors/en.wikipedia/Ravine_du_Sud/2018-01-01/2018-02-01',
+            '/api/page/bot_data/en.wikipedia/Ravine_du_Sud',
+            '/api/page/automated_edits/enwiki/Ravine_du_Sud',
         ]);
     }
 }


### PR DESCRIPTION
Also adds a 'ip_editors' property to the main articleinfo API response.