### PR TITLE
Make API responses more consistent

### DIFF
--- a/config/packages/nelmio_api_doc.yaml
+++ b/config/packages/nelmio_api_doc.yaml
@@ -233,12 +233,18 @@ nelmio_api_doc:
                             example: Metallica
                         namespace:
                             $ref: '#/components/schemas/Namespace'
+                        project:
+                            type: string
+                            example: en.wikipedia.org
+                        username:
+                            type: string
+                            example: Jimbo Wales
                         rev_id:
                             type: integer
                             example: 123
                         timestamp:
                             type: date-time
-                            example: 20200101125959
+                            example: '2020-01-01T12:59:59Z'
                         minor:
                             type: boolean
                             example: 0
@@ -296,7 +302,7 @@ nelmio_api_doc:
                             timestamp:
                                 type: date-time
                                 description: Timestamp of the initial revision
-                                example: 20200101125959
+                                example: '2020-01-01T12:59:59'
                             rev_id:
                                 type: integer
                                 description: Revision ID (correlates to `archive.ar_rev_id` for deleted pages)

--- a/src/Controller/AutomatedEditsController.php
+++ b/src/Controller/AutomatedEditsController.php
@@ -158,7 +158,7 @@ class AutomatedEditsController extends XtoolsController
      *         "namespace"="|all|\d+",
      *         "start"="|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *     },
      *     defaults={"namespace"=0, "start"=false, "end"=false, "offset"=false}
      * )
@@ -189,7 +189,7 @@ class AutomatedEditsController extends XtoolsController
      *       "namespace"="|all|\d+",
      *       "start"="|\d{4}-\d{2}-\d{2}",
      *       "end"="|\d{4}-\d{2}-\d{2}",
-     *       "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *       "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *   },
      *   defaults={"namespace"=0, "start"=false, "end"=false, "offset"=false}
      * )
@@ -214,7 +214,7 @@ class AutomatedEditsController extends XtoolsController
      *       "namespace"="|all|\d+",
      *       "start"="|\d{4}-\d{2}-\d{2}",
      *       "end"="|\d{4}-\d{2}-\d{2}",
-     *       "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *       "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *   },
      *   defaults={"namespace"=0, "start"=false, "end"=false, "offset"=false}
      * )
@@ -402,10 +402,9 @@ class AutomatedEditsController extends XtoolsController
         $results = $this->autoEdits->getNonAutomatedEdits(true);
         $out = $this->addFullPageTitlesAndContinue('nonautomated_edits', [], $results);
         if (count($results) === $this->limit) {
-            $out['continue'] = (new DateTime(end($results)['timestamp']))->format('Y-m-d\TH:i:s');
+            $out['continue'] = (new DateTime(end($results)['timestamp']))->format('Y-m-d\TH:i:s\Z');
         }
 
-        $this->addApiWarnings();
         return $this->getFormattedApiResponse($out);
     }
 
@@ -419,7 +418,7 @@ class AutomatedEditsController extends XtoolsController
      *       "namespace"="|all|\d+",
      *       "start"="|\d{4}-\d{2}-\d{2}",
      *       "end"="|\d{4}-\d{2}-\d{2}",
-     *       "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}",
+     *       "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}Z?",
      *   },
      *   defaults={"namespace"=0, "start"=false, "end"=false, "offset"=false, "limit"=50},
      *   methods={"GET"}
@@ -477,17 +476,9 @@ class AutomatedEditsController extends XtoolsController
         $results = $this->autoEdits->getAutomatedEdits(true);
         $out = $this->addFullPageTitlesAndContinue('automated_edits', $extras, $results);
         if (count($results) === $this->limit) {
-            $out['continue'] = (new DateTime(end($results)['timestamp']))->format('Y-m-d\TH:i:s');
+            $out['continue'] = (new DateTime(end($results)['timestamp']))->format('Y-m-d\TH:i:s\Z');
         }
 
-        $this->addApiWarnings();
         return $this->getFormattedApiResponse($out);
-    }
-
-    private function addApiWarnings(): void
-    {
-        $this->addApiWarningAboutDates(['timestamp']);
-        $this->addApiWarningAboutPageTitles();
-        $this->addFlash('warning', 'In XTools 3.20, the minor property will return a boolean instead of 0 or 1.');
     }
 }

--- a/src/Controller/CategoryEditsController.php
+++ b/src/Controller/CategoryEditsController.php
@@ -143,7 +143,7 @@ class CategoryEditsController extends XtoolsController
      *         "categories"="(.+?)(?!\/(?:|\d{4}-\d{2}-\d{2})(?:\/(|\d{4}-\d{2}-\d{2}))?)?$",
      *         "start"="|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}",
+     *         "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}Z?",
      *     },
      *     defaults={"start"=false, "end"=false, "offset"=false}
      * )
@@ -168,7 +168,7 @@ class CategoryEditsController extends XtoolsController
      *       "categories"="(.+?)(?!\/(?:|\d{4}-\d{2}-\d{2}))?",
      *       "start"="|\d{4}-\d{2}-\d{2}",
      *       "end"="|\d{4}-\d{2}-\d{2}",
-     *       "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}",
+     *       "offset"="|\d{4}-?\d{2}-?\d{2}T?\d{2}:?\d{2}:?\d{2}Z?",
      *   },
      *   defaults={"start"=false, "end"=false, "offset"=false}
      * )
@@ -242,14 +242,13 @@ class CategoryEditsController extends XtoolsController
         $this->setupCategoryEdits($categoryEditsRepo);
 
         $ret = [
+            // Ensure `categories` is always treated as an array, even if one element.
+            // (XtoolsController would otherwise see it as a single value from the URL query string).
+            'categories' => $this->categories,
             'total_editcount' => $this->categoryEdits->getEditCount(),
             'category_editcount' => $this->categoryEdits->getCategoryEditCount(),
         ];
 
-        if (1 === count($this->categoryEdits->getCategories())) {
-            $this->addFlash('warning', 'In XTools 3.20, the categories property will always return an array, '.
-                'even if only one category was provided.');
-        }
         return $this->getFormattedApiResponse($ret);
     }
 }

--- a/src/Controller/EditCounterController.php
+++ b/src/Controller/EditCounterController.php
@@ -694,7 +694,7 @@ class EditCounterController extends XtoolsController
      *     methods={"GET"}
      * )
      * @OA\Tag(name="User API")
-     * @OA\Get(description="Get the number of edits a user has made grouped by namespace, year, and month.")
+     * @OA\Get(description="Get the number of edits a user has made grouped by namespace and month.")
      * @OA\Parameter(ref="#/components/parameters/Project")
      * @OA\Parameter(ref="#/components/parameters/UsernameOrIp")
      * @OA\Response(
@@ -705,10 +705,15 @@ class EditCounterController extends XtoolsController
      *         @OA\Property(property="username", ref="#/components/parameters/UsernameOrIp/schema"),
      *         @OA\Property(property="totals", type="object", example={
      *             "0": {
-     *                 "2020": {"1": 40, "12": 50},
-     *                 "2021": {"1": 5, "12": 25}
+     *                 "2020-11": 40,
+     *                 "2020-12": 50,
+     *                 "2021-01": 5
      *             },
-     *             "3": {"2022": {"1": 1, "12": 4}}
+     *             "3": {
+     *                 "2020-11": 0,
+     *                 "2020-12": 10,
+     *                 "2021-01": 0
+     *             }
      *         })
      *     )
      * )
@@ -738,8 +743,6 @@ class EditCounterController extends XtoolsController
         // Ensure 'totals' keys are strings, see T292031.
         $ret['totals'] = (object)$ret['totals'];
 
-        $this->addFlash('warning', 'In XTools 3.20, the totals property will return an array '
-            . "keyed by namespace and then year/month in the format 'YYYY-MM' with the count as values.");
         return $this->getFormattedApiResponse($ret);
     }
 

--- a/src/Controller/EditSummaryController.php
+++ b/src/Controller/EditSummaryController.php
@@ -67,18 +67,16 @@ class EditSummaryController extends XtoolsController
      *     defaults={"namespace"="all", "start"=false, "end"=false}
      * )
      * @param EditSummaryRepository $editSummaryRepo
-     * @param I18nHelper $i18n
      * @return Response
      * @codeCoverageIgnore
      */
-    public function resultAction(EditSummaryRepository $editSummaryRepo, I18nHelper $i18n): Response
+    public function resultAction(EditSummaryRepository $editSummaryRepo): Response
     {
         // Instantiate an EditSummary, treating the past 150 edits as 'recent'.
         $editSummary = new EditSummary(
             $editSummaryRepo,
             $this->project,
             $this->user,
-            $i18n,
             $this->namespace,
             $this->start,
             $this->end,
@@ -144,11 +142,10 @@ class EditSummaryController extends XtoolsController
      * @OA\Response(response=503, ref="#/components/responses/503")
      * @OA\Response(response=504, ref="#/components/responses/504")
      * @param EditSummaryRepository $editSummaryRepo
-     * @param I18nHelper $i18n
      * @return JsonResponse
      * @codeCoverageIgnore
      */
-    public function editSummariesApiAction(EditSummaryRepository $editSummaryRepo, I18nHelper $i18n): JsonResponse
+    public function editSummariesApiAction(EditSummaryRepository $editSummaryRepo): JsonResponse
     {
         $this->recordApiUsage('user/edit_summaries');
 
@@ -157,7 +154,6 @@ class EditSummaryController extends XtoolsController
             $editSummaryRepo,
             $this->project,
             $this->user,
-            $i18n,
             $this->namespace,
             $this->start,
             $this->end,

--- a/src/Controller/GlobalContribsController.php
+++ b/src/Controller/GlobalContribsController.php
@@ -129,7 +129,7 @@ class GlobalContribsController extends XtoolsController
      *         "namespace"="|all|\d+",
      *         "start"="|\d*|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *     },
      *     defaults={
      *         "namespace"="all",
@@ -174,7 +174,7 @@ class GlobalContribsController extends XtoolsController
      *         "namespace"="|all|\d+",
      *         "start"="|\d*|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *     },
      *     defaults={
      *         "namespace"="all",
@@ -231,12 +231,10 @@ class GlobalContribsController extends XtoolsController
 
         $results = $globalContribs->globalEdits();
         $results = array_map(function (Edit $edit) {
-            return $edit->getForJson(true, true);
+            return $edit->getForJson(true);
         }, array_values($results));
         $results = $this->addFullPageTitlesAndContinue('globalcontribs', [], $results);
 
-        $this->addApiWarningAboutDates(['timestamp']);
-        $this->addApiWarningAboutPageTitles();
         return $this->getFormattedApiResponse($results);
     }
 }

--- a/src/Controller/PageInfoController.php
+++ b/src/Controller/PageInfoController.php
@@ -248,7 +248,7 @@ class PageInfoController extends XtoolsController
      *         @OA\Property(property="created_rev_id", type="integer"),
      *         @OA\Property(property="modified_at", type="date"),
      *         @OA\Property(property="secs_since_last_edit", type="integer"),
-     *         @OA\Property(property="last_edit_id", type="integer"),
+     *         @OA\Property(property="modified_rev_id", type="integer"),
      *         @OA\Property(property="assessment", type="object", example={
      *             "value":"FA",
      *             "color": "#9CBDFF",
@@ -290,12 +290,6 @@ class PageInfoController extends XtoolsController
             return $this->getApiHtmlResponse($this->project, $this->page, $data);
         }
 
-        $this->addApiWarningAboutDates(['created_at', 'modified_at']);
-        $this->addFlash('warning', 'In XTools 3.20, the author and author_editcount properties will be ' .
-            'renamed to creator and creator_editcount, respectively.');
-        $this->addFlash('warning', 'In XTools 3.20, the last_edit_id property will be renamed to modified_rev_id');
-        $this->addFlash('warning', 'In XTools 3.20, the watchers property will return null instead of 0 ' .
-            'if the number of page watchers is unknown.');
         return $this->getFormattedApiResponse($data);
     }
 
@@ -523,11 +517,11 @@ class PageInfoController extends XtoolsController
      *                 "minor": 15,
      *                 "first_edit": {
      *                     "id": 12345,
-     *                     "timestamp": 20200101125959
+     *                     "timestamp": "2020-01-01T12:59:59Z"
      *                 },
      *                 "last_edit": {
      *                     "id": 54321,
-     *                     "timestamp": 20200120125959
+     *                     "timestamp": "2020-01-20T12:59:59Z"
      *                 }
      *             }
      *         }),
@@ -554,7 +548,6 @@ class PageInfoController extends XtoolsController
             $this->getBoolVal('nobots')
         );
 
-        $this->addApiWarningAboutDates(['timestamp']);
         return $this->getFormattedApiResponse([
             'top_editors' => $topEditors,
         ]);

--- a/src/Controller/PagesController.php
+++ b/src/Controller/PagesController.php
@@ -119,7 +119,7 @@ class PagesController extends XtoolsController
      *         "deleted"="|all|live|deleted",
      *         "start"="|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *     },
      *     defaults={
      *         "namespace"=0,
@@ -283,8 +283,8 @@ class PagesController extends XtoolsController
      *         @OA\Property(property="namespace", ref="#/components/schemas/Namespace"),
      *         @OA\Property(property="redirects", ref="#/components/parameters/Redirects/schema"),
      *         @OA\Property(property="deleted", ref="#components/parameters/Deleted/schema"),
-     *         @OA\Property(property="start", ref="#components/parameters/start/schema"),
-     *         @OA\Property(property="end", ref="#components/parameters/end/schema"),
+     *         @OA\Property(property="start", ref="#components/parameters/Start/schema"),
+     *         @OA\Property(property="end", ref="#components/parameters/End/schema"),
      *         @OA\Property(property="counts", type="object", example={
      *             "0": {
      *                 "count": 5,
@@ -335,7 +335,7 @@ class PagesController extends XtoolsController
      *         "deleted"="|all|live|deleted",
      *         "start"="|\d{4}-\d{2}-\d{2}",
      *         "end"="|\d{4}-\d{2}-\d{2}",
-     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}",
+     *         "offset"="|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z?",
      *     },
      *     defaults={
      *         "namespace"=0,
@@ -401,8 +401,6 @@ class PagesController extends XtoolsController
             $ret['continue'] = $pages->getLastTimestamp();
         }
 
-        $this->addApiWarningAboutDates(['timestamp']);
-        $this->addApiWarningAboutPageTitles();
         return $this->getFormattedApiResponse($ret);
     }
 

--- a/src/Controller/TopEditsController.php
+++ b/src/Controller/TopEditsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Controller;
 
 use App\Helper\AutomatedEditsHelper;
+use App\Model\Edit;
 use App\Model\TopEdits;
 use App\Repository\TopEditsRepository;
 use OpenApi\Annotations as OA;
@@ -244,7 +245,6 @@ class TopEditsController extends XtoolsController
         $topEdits = $this->setUpTopEdits($topEditsRepo, $autoEditsHelper);
         $topEdits->prepareData();
 
-        $this->addApiWarningAboutPageTitles();
         return $this->getFormattedApiResponse([
             'top_edits' => (object)$topEdits->getTopEdits(),
         ]);
@@ -312,15 +312,12 @@ class TopEditsController extends XtoolsController
         $this->recordApiUsage('user/topedits');
 
         $topEdits = $this->setUpTopEdits($topEditsRepo, $autoEditsHelper);
-        $topEdits->prepareData(false);
+        $topEdits->prepareData();
 
-        $this->addApiWarningAboutDates(['timestamp']);
-        if (false !== strpos($this->page->getTitle(true), '_')) {
-            $this->addFlash('warning', 'In XTools 3.20, the page property will be returned ' .
-                'with spaces instead of underscores.');
-        }
         return $this->getFormattedApiResponse([
-            'top_edits' => $topEdits->getTopEdits(),
+            'top_edits' => array_map(function (Edit $edit) {
+                return $edit->getForJson();
+            }, $topEdits->getTopEdits()),
         ]);
     }
 }

--- a/src/Controller/XtoolsController.php
+++ b/src/Controller/XtoolsController.php
@@ -954,6 +954,9 @@ abstract class XtoolsController extends AbstractController
             } elseif (is_string($value) && false !== strpos($value, '|')) {
                 // Any pipe-separated values should be returned as an array.
                 $params[$param] = explode('|', $value);
+            } elseif ($value instanceof DateTime) {
+                // Convert DateTime objects to ISO 8601 strings.
+                $params[$param] = $value->format('Y-m-d\TH:i:s\Z');
             }
         }
 
@@ -1003,7 +1006,7 @@ abstract class XtoolsController extends AbstractController
             // Use the timestamp of the last Edit as the value for the 'continue' return key,
             //   which can be used as a value for 'offset' in order to paginate results.
             $timestamp = array_slice($out[$key], -1, 1)[0]['timestamp'];
-            $out['continue'] = (new DateTime($timestamp))->format('Y-m-d\TH:i:s');
+            $out['continue'] = (new DateTime($timestamp))->format('Y-m-d\TH:i:s\Z');
         }
 
         return $out;
@@ -1052,24 +1055,5 @@ abstract class XtoolsController extends AbstractController
             $msg = $this->i18n->msg($key, $vars);
         }
         $this->addFlash($type, $msg);
-    }
-
-    /**
-     * @todo To be removed in XTools 3.20
-     * @param array $keys
-     */
-    protected function addApiWarningAboutDates(array $keys): void
-    {
-        $this->addFlash('warning', 'In XTools 3.20, the ' . $this->i18n->getIntuition()->listToText($keys) .
-            ' properties will be returned in ISO 8601 format: YYYY-MM-DDTHH:MM:SSZ');
-    }
-
-    /**
-     * @todo To be removed in XTools 3.20
-     */
-    protected function addApiWarningAboutPageTitles(): void
-    {
-        $this->addFlash('warning', 'In XTools 3.20, full_page_title and page_title will return ' .
-            'page titles with spaces instead of underscores.');
     }
 }

--- a/src/Model/AutoEdits.php
+++ b/src/Model/AutoEdits.php
@@ -148,10 +148,10 @@ class AutoEdits extends Model
 
     /**
      * Get non-automated contributions for this user.
-     * @param bool $raw Whether to return raw data from the database, or get Edit objects.
+     * @param bool $forJson
      * @return string[]|Edit[]
      */
-    public function getNonAutomatedEdits(bool $raw = false): array
+    public function getNonAutomatedEdits(bool $forJson = false): array
     {
         if (isset($this->nonAutomatedEdits)) {
             return $this->nonAutomatedEdits;
@@ -167,10 +167,6 @@ class AutoEdits extends Model
             $this->limit
         );
 
-        if ($raw) {
-            return $revs;
-        }
-
         $this->nonAutomatedEdits = Edit::getEditsFromRevs(
             $this->pageRepo,
             $this->editRepo,
@@ -180,15 +176,21 @@ class AutoEdits extends Model
             $revs
         );
 
+        if ($forJson) {
+            return array_map(function (Edit $edit) {
+                return $edit->getForJson();
+            }, $this->nonAutomatedEdits);
+        }
+
         return $this->nonAutomatedEdits;
     }
 
     /**
      * Get automated contributions for this user.
-     * @param bool $raw Whether to return raw data from the database, or get Edit objects.
+     * @param bool $forJson
      * @return Edit[]
      */
-    public function getAutomatedEdits(bool $raw = false): array
+    public function getAutomatedEdits(bool $forJson = false): array
     {
         if (isset($this->automatedEdits)) {
             return $this->automatedEdits;
@@ -201,12 +203,9 @@ class AutoEdits extends Model
             $this->start,
             $this->end,
             $this->tool,
-            $this->offset
+            $this->offset,
+            $this->limit
         );
-
-        if ($raw) {
-            return $revs;
-        }
 
         $this->automatedEdits = Edit::getEditsFromRevs(
             $this->pageRepo,
@@ -216,6 +215,12 @@ class AutoEdits extends Model
             $this->user,
             $revs
         );
+
+        if ($forJson) {
+            return array_map(function (Edit $edit) {
+                return $edit->getForJson();
+            }, $this->automatedEdits);
+        }
 
         return $this->automatedEdits;
     }

--- a/src/Model/EditSummary.php
+++ b/src/Model/EditSummary.php
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 
 namespace App\Model;
 
-use App\Helper\I18nHelper;
 use App\Repository\EditSummaryRepository;
 use DateTime;
 
@@ -13,8 +12,6 @@ use DateTime;
  */
 class EditSummary extends Model
 {
-    protected I18nHelper $i18n;
-
     /** @var int Number of edits from present to consider as 'recent'. */
     protected int $numEditsRecent;
 
@@ -43,7 +40,6 @@ class EditSummary extends Model
      * @param EditSummaryRepository $repository
      * @param Project $project The project we're working with.
      * @param User $user The user to process.
-     * @param I18nHelper $i18n
      * @param int|string $namespace Namespace ID or 'all' for all namespaces.
      * @param int|false $start Start date as Unix timestamp.
      * @param int|false $end End date as Unix timestamp.
@@ -53,7 +49,6 @@ class EditSummary extends Model
         EditSummaryRepository $repository,
         Project $project,
         User $user,
-        I18nHelper $i18n,
         $namespace,
         $start = false,
         $end = false,
@@ -62,7 +57,6 @@ class EditSummary extends Model
         $this->repository = $repository;
         $this->project = $project;
         $this->user = $user;
-        $this->i18n = $i18n;
         $this->namespace = $namespace;
         $this->start = $start;
         $this->end = $end;
@@ -214,7 +208,7 @@ class EditSummary extends Model
         // Extract the date out of the date field
         $timestamp = DateTime::createFromFormat('YmdHis', $row['rev_timestamp']);
 
-        $monthKey = $this->i18n->dateFormat($timestamp, 'yyyy-MM');
+        $monthKey = $timestamp->format('Y-m');
 
         // Grand total for number of edits
         $this->data['total_edits']++;

--- a/src/Model/PageInfoApi.php
+++ b/src/Model/PageInfoApi.php
@@ -141,11 +141,13 @@ class PageInfoApi extends Model
                 'minor' => $row['minor'],
                 'first_edit' => [
                     'id' => $row['first_revid'],
-                    'timestamp' => $row['first_timestamp'],
+                    'timestamp' => DateTime::createFromFormat('YmdHis', $row['first_timestamp'])
+                        ->format('Y-m-d\TH:i:s\Z'),
                 ],
                 'latest_edit' => [
                     'id' => $row['latest_revid'],
-                    'timestamp' => $row['latest_timestamp'],
+                    'timestamp' => DateTime::createFromFormat('YmdHis', $row['latest_timestamp'])
+                        ->format('Y-m-d\TH:i:s\Z'),
                 ],
             ];
         }
@@ -281,7 +283,7 @@ class PageInfoApi extends Model
         $data = [
             'project' => $project->getDomain(),
             'page' => $page->getTitle(),
-            'watchers' => (int) $page->getWatchers(),
+            'watchers' => $page->getWatchers(),
             'pageviews' => $page->getLatestPageviews(),
             'pageviews_offset' => self::PAGEVIEWS_OFFSET,
         ];
@@ -306,11 +308,6 @@ class PageInfoApi extends Model
             $modifiedDateTime = DateTime::createFromFormat('YmdHis', $info['modified_at']);
             $secsSinceLastEdit = (new DateTime)->getTimestamp() - $modifiedDateTime->getTimestamp();
 
-            // Some wikis (such foundation.wikimedia.org) may be missing the creation date.
-            $creationDateTime = false === $creationDateTime
-                ? null
-                : $creationDateTime->format('Y-m-d');
-
             $assessment = $page->getProject()
                 ->getPageAssessments()
                 ->getAssessment($page);
@@ -320,13 +317,13 @@ class PageInfoApi extends Model
                 'editors' => (int) $info['num_editors'],
                 'ip_edits' => (int) $info['ip_edits'],
                 'minor_edits' => (int) $info['minor_edits'],
-                'author' => $info['author'],
-                'author_editcount' => null === $info['author_editcount'] ? null : (int) $info['author_editcount'],
+                'creator' => $info['creator'],
+                'creator_editcount' => null === $info['creator_editcount'] ? null : (int) $info['creator_editcount'],
                 'created_at' => $creationDateTime,
                 'created_rev_id' => $info['created_rev_id'],
-                'modified_at' => $modifiedDateTime->format('Y-m-d H:i'),
+                'modified_at' => $modifiedDateTime,
                 'secs_since_last_edit' => $secsSinceLastEdit,
-                'last_edit_id' => (int) $info['modified_rev_id'],
+                'modified_rev_id' => (int) $info['modified_rev_id'],
                 'assessment' => $assessment,
             ]);
         }

--- a/src/Model/Pages.php
+++ b/src/Model/Pages.php
@@ -135,7 +135,7 @@ class Pages extends Model
 
         $numResults = count($this->getResults()[$this->getNamespace()]);
         $timestamp = new DateTime($this->getResults()[$this->getNamespace()][$numResults - 1]['timestamp']);
-        return $timestamp->format('Y-m-d\TH:i:s');
+        return $timestamp->format('Y-m-d\TH:i:s\Z');
     }
 
     /**

--- a/src/Repository/PageInfoRepository.php
+++ b/src/Repository/PageInfoRepository.php
@@ -304,8 +304,8 @@ class PageInfoRepository extends AutoEditsRepository
         $sql = "SELECT *, (
                     SELECT user_editcount
                     FROM $userTable
-                    WHERE user_id = author_user_id
-                ) AS author_editcount
+                    WHERE user_id = creator_user_id
+                ) AS creator_editcount
                 FROM (
                     (
                         SELECT COUNT(rev_id) AS num_edits,
@@ -320,8 +320,8 @@ class PageInfoRepository extends AutoEditsRepository
                     (
                         # With really old pages, the rev_timestamp may need to be sorted ASC,
                         #   and the lowest rev_id may not be the first revision.
-                        SELECT actor_name AS author,
-                               actor_user AS author_user_id,
+                        SELECT actor_name AS creator,
+                               actor_user AS creator_user_id,
                                rev_timestamp AS created_at,
                                rev_id AS created_rev_id
                         FROM $revTable

--- a/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
+++ b/templates/bundles/NelmioApiDocBundle/SwaggerUi/index.html.twig
@@ -1,5 +1,21 @@
 {% extends '@!NelmioApiDoc/SwaggerUi/index.html.twig' %}
 
+{% block stylesheets %}
+    {{ nelmioAsset(assets_mode, 'swagger-ui/swagger-ui.css') }}
+    {{ nelmioAsset(assets_mode, 'style.css') }}
+    <style>
+        body {
+            background: url('{{ asset('/build/images/gradient.png') }}');
+        }
+        header::before {
+            background: #fff url('{{ asset('/build/images/gradient.png') }}');
+        }
+        header #logo img {
+            background: transparent;
+        }
+    </style>
+{% endblock %}
+
 {% block swagger_initialization %}
     <script type="text/javascript">
         window.onload = loadSwaggerUI({

--- a/templates/editCounter/monthcounts.html.twig
+++ b/templates/editCounter/monthcounts.html.twig
@@ -10,7 +10,7 @@
 
 {% if not project.userHasOptedIn(user) %}
     {{ wiki.userOptedOut(project, user) }}
-{% elseif ec.monthTotals|length > 0 %}
+{% elseif ec.monthCounts.monthLabels|length > 0 %}
     <table class="sr-only">
         <thead>
             <tr>
@@ -22,11 +22,11 @@
             </tr>
         </thead>
         <tbody>
-            {% for month,namespaces in ec.monthCountsWithNamespaces %}
+            {% for month,counts in ec.monthCountsWithNamespaces %}
                 <tr>
                     <td>{{ month }}</td>
-                    <td>{{ ec.monthTotals[month]|num_format }}</td>
-                    {% for _ns,count in namespaces %}
+                    <td>{{ counts|reduce((carry, v) => carry + v)|num_format }}</td>
+                    {% for _ns,count in counts %}
                         <td>{{ count|num_format }}</td>
                     {% endfor %}
                 </tr>
@@ -51,23 +51,20 @@
             var maxTotal = 0;
 
             // Format data for use in charts.
-            {% for nsId,namespaceData in ec.monthCounts.totals %}
+            {% for nsId,months in ec.monthCounts.totals %}
                 var dataset = {
                     label: "{{ nsName(nsId, project.namespaces) }}",
                     backgroundColor: "{{ color(nsId) }}",
                     data: []
                 };
 
-                {% for year,yearData in namespaceData %}
-                    {% for month,monthData in yearData %}
-                        dataset.data.push({{ monthData }});
-
-                        // Determine maximum value for the totals. This is needed
-                        //   so that we know how much spacing to add in the labels.
-                        if ({{ monthData }} > maxTotal) {
-                            maxTotal = {{ monthData }};
-                        }
-                    {% endfor %}
+                {% for month,count in months %}
+                    dataset.data.push({{ count }});
+                    // Determine maximum value for the totals. This is needed
+                    //   so that we know how much spacing to add in the labels.
+                    if ({{ count }} > maxTotal) {
+                        maxTotal = {{ count }};
+                    }
                 {%- endfor -%}
 
                 datasets.push(dataset);

--- a/templates/editCounter/monthcounts.wikitext.twig
+++ b/templates/editCounter/monthcounts.wikitext.twig
@@ -16,9 +16,9 @@
 ! {{ msg('count') }}
 |-
 {% set labels = ec.monthCounts.monthLabels %}
-{% for month,total in ec.monthTotals %}
+{% for month,ns in ec.monthCountsWithNamespaces %}
 | {{ labels[loop.index0] }}
-| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ total }}}}
+| {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ ns|reduce((carry, v) => carry + v) }}}}
 |-
 {% endfor %}
 |}

--- a/templates/editSummary/result.html.twig
+++ b/templates/editSummary/result.html.twig
@@ -150,7 +150,7 @@
                         {% for month, counts in es.monthCounts %}
                             <tr>
                                 <td class="sort-entry--month" data-value="{{ month|replace({'-': ''}) }}">
-                                    {{ month }}
+                                    {{ (month~'-01')|date_format('yyyy-MM') }}
                                 </td>
                                 <td class="sort-entry--total-edits" data-value="{{ counts.total }}">
                                     {{ counts.total|num_format }}

--- a/templates/pageInfo/api.html.twig
+++ b/templates/pageInfo/api.html.twig
@@ -7,7 +7,7 @@
         -#}{{ data.revisions|num_format }} {{ msg('num-revisions', [data.revisions]) }}{{ msg('comma-character') }}
     {% else %}{#-
         -#}{{ msg('num-revisions-since', [data.revisions|num_format, data.revisions, "<a target='_blank' href='" ~ wiki.pageUrlRaw('Special:PermaLink/' ~ data.created_rev_id, project) ~ "'>" ~ data.created_at ~ "</a>"]) }}
-        <span style="color:#A2A9B1">(<a href="{{ wiki.pageUrlRaw('Special:Diff/' ~ data.last_edit_id, project) }}" style="color:#A2A9B1">+{{ formatDuration(data.secs_since_last_edit) }}</a>)</span>{{ msg('comma-character') }}
+        <span style="color:#A2A9B1">(<a href="{{ wiki.pageUrlRaw('Special:Diff/' ~ data.modified_rev_id, project) }}" style="color:#A2A9B1">+{{ formatDuration(data.secs_since_last_edit) }}</a>)</span>{{ msg('comma-character') }}
         {{ data.editors|num_format }} {{ msg('num-editors', [data.editors]) }}{{ msg('comma-character') }}
     {% endif %}
 {% endif %}
@@ -16,11 +16,11 @@
 {% endif %}
 {%- if data.pageviews is defined -%}
 <a target="_blank" href="https://pageviews.wmcloud.org/?project={{ project.domain }}&amp;pages={{ page.title|e('url') }}&amp;range=latest-30">{{ data.pageviews|num_format }} {{ msg('num-pageviews', [data.pageviews]) }}</a> ({{ data.pageviews_offset|num_format }} {{ msg('num-days', [data.pageviews_offset]) }}){% endif -%}
-{% if data.error is not defined and data.author is not empty -%}
+{% if data.error is not defined and data.creator is not empty -%}
     {{ msg('comma-character') }}
-    {{ msg('created-by')|lower }}: {{ wiki.userLink(data.author, project) }}
-    {# IPs have an edit count of null for performance reasons, so we simply don't show anything #}{% if data.author_editcount != null %}
-    (<a target="_blank" title="{{ msg('approximate') }}" href="{{ url('EditCounterResult', { 'project': project.domain, 'username': data.author }) }}">{{ data.author_editcount|num_format }}</a>){% endif %}
+    {{ msg('created-by')|lower }}: {{ wiki.userLink(data.creator, project) }}
+    {# IPs have an edit count of null for performance reasons, so we simply don't show anything #}{% if data.creator_editcount != null %}
+    (<a target="_blank" title="{{ msg('approximate') }}" href="{{ url('EditCounterResult', { 'project': project.domain, 'username': data.creator }) }}">{{ data.creator_editcount|num_format }}</a>){% endif %}
 {% endif %}
  &middot;
 <a target="_blank" href="{{ url('PageInfoResult', { 'project': project.domain, 'page': page.title }) }}">{{ msg('see-full-page-stats') }}</a>

--- a/tests/Controller/EditCounterControllerTest.php
+++ b/tests/Controller/EditCounterControllerTest.php
@@ -128,6 +128,7 @@ class EditCounterControllerTest extends ControllerTestAdapter
             '/ec-timecard/en.wikipedia/Example',
             '/ec-yearcounts/en.wikipedia/Example',
             '/ec-monthcounts/en.wikipedia/Example',
+            '/ec-monthcounts/en.wikipedia/Example?format=wikitext',
             '/ec-rightschanges/en.wikipedia/Example',
             '/ec-latestglobal/en.wikipedia/Example',
         ]);

--- a/tests/Controller/PageInfoControllerTest.php
+++ b/tests/Controller/PageInfoControllerTest.php
@@ -49,17 +49,15 @@ class PageInfoControllerTest extends ControllerTestAdapter
         static::assertEquals($data['page'], 'Main Page');
         static::assertTrue($data['revisions'] > 4000);
         static::assertTrue($data['editors'] > 400);
-        static::assertEquals($data['author'], 'TwoOneTwo');
-        static::assertEquals($data['created_at'], '2002-01-26');
+        static::assertEquals($data['creator'], 'TwoOneTwo');
+        static::assertEquals($data['created_at'], '2002-01-26T15:28:12Z');
         static::assertEquals($data['created_rev_id'], 139992);
 
         static::assertEquals(
             [
-                // 'warning' is only temporary so that API deprecations can be announced. To be removed in v3.20
-                'warning',
                 'project', 'page', 'watchers', 'pageviews', 'pageviews_offset',  'revisions', 'editors',
-                'ip_edits', 'minor_edits', 'author', 'author_editcount', 'created_at',  'created_rev_id',
-                'modified_at', 'secs_since_last_edit', 'last_edit_id', 'assessment', 'elapsed_time',
+                'ip_edits', 'minor_edits', 'creator', 'creator_editcount', 'created_at',  'created_rev_id',
+                'modified_at', 'secs_since_last_edit', 'modified_rev_id', 'assessment', 'elapsed_time',
             ],
             array_keys($data)
         );

--- a/tests/Controller/XtoolsControllerTest.php
+++ b/tests/Controller/XtoolsControllerTest.php
@@ -472,7 +472,7 @@ class XtoolsControllerTest extends ControllerTestAdapter
                     'timestamp' => '2020-01-03T12:59:59',
                 ],
             ],
-            'continue' => '2020-01-03T12:59:59',
+            'continue' => '2020-01-03T12:59:59Z',
         ], $newOut);
     }
 

--- a/tests/Model/AutoEditsTest.php
+++ b/tests/Model/AutoEditsTest.php
@@ -90,13 +90,23 @@ class AutoEditsTest extends TestAdapter
             'comment' => 'Test',
         ];
 
-        $this->aeRepo->expects(static::exactly(2))
+        $this->aeRepo->expects(static::once())
             ->method('getNonAutomatedEdits')
             ->willReturn([$rev]);
 
         $autoEdits = $this->getAutoEdits();
         $rawEdits = $autoEdits->getNonAutomatedEdits(true);
-        static::assertArraySubset($rev, $rawEdits[0]);
+        static::assertSame([
+            'page_title' => 'Test page',
+            'namespace' => 0,
+            'username' => 'Test user',
+            'rev_id' => 123,
+            'timestamp' => '2017-01-01T00:00:00Z',
+            'minor' => false,
+            'length' => 5,
+            'length_change' => -5,
+            'comment' => 'Test',
+        ], $rawEdits[0]);
 
         $page = Page::newFromRow($this->pageRepo, $this->project, [
             'page_title' => 'Test_page',
@@ -158,13 +168,23 @@ class AutoEditsTest extends TestAdapter
             'comment' => 'Test ([[WP:TW|TW]])',
         ];
 
-        $this->aeRepo->expects(static::exactly(2))
+        $this->aeRepo->expects(static::once())
             ->method('getAutomatedEdits')
             ->willReturn([$rev]);
 
         $autoEdits = $this->getAutoEdits();
-        $rawEdits = $autoEdits->getAutomatedEdits(true);
-        static::assertArraySubset($rev, $rawEdits[0]);
+        $editObjs = $autoEdits->getAutomatedEdits(true);
+        static::assertSame([
+            'page_title' => 'Test page',
+            'namespace' => 1,
+            'username' => 'Test user',
+            'rev_id' => 123,
+            'timestamp' => '2017-01-01T00:00:00Z',
+            'minor' => false,
+            'length' => 5,
+            'length_change' => -5,
+            'comment' => 'Test ([[WP:TW|TW]])',
+        ], $editObjs[0]);
 
         $page = Page::newFromRow($this->pageRepo, $this->project, [
             'page_title' => 'Test_page',

--- a/tests/Model/EditCounterTest.php
+++ b/tests/Model/EditCounterTest.php
@@ -269,66 +269,51 @@ class EditCounterTest extends TestAdapter
         // Mock current time by passing it in (dummy parameter, so to speak).
         $monthCounts = $this->editCounter->monthCounts($mockTime);
 
-        // Make sure zeros were filled in for months with no edits,
-        //   and for each namespace.
+        // Make sure zeros were filled in for months with no edits, and for each namespace.
         static::assertArraySubset(
             [
-                1 => 0,
-                2 => 0,
-                3 => 20,
-                4 => 0,
+                '2017-01' => 0,
+                '2017-02' => 0,
+                '2017-03' => 20,
+                '2017-04' => 0,
             ],
-            $monthCounts['totals'][0][2017]
+            $monthCounts['totals'][0]
         );
         static::assertArraySubset(
             [
-                12 => 0,
+                '2016-12' => 0,
             ],
-            $monthCounts['totals'][1][2016]
+            $monthCounts['totals'][1]
         );
 
         // Assert only active months are reported.
-        static::assertEquals([12], array_keys($monthCounts['totals'][0][2016]));
-        static::assertEquals(['01', '02', '03', '04'], array_keys($monthCounts['totals'][0][2017]));
-
-        // Assert that only active years are reported
-        static::assertEquals([2016, 2017], array_keys($monthCounts['totals'][0]));
+        static::assertArrayNotHasKey('2016-11', $monthCounts['totals'][0]);
+        static::assertArrayHasKey('2016-12', $monthCounts['totals'][0]);
+        static::assertArrayHasKey('2017-04', $monthCounts['totals'][0]);
+        static::assertArrayNotHasKey('2017-05', $monthCounts['totals'][0]);
 
         // Assert that only active namespaces are reported.
-        static::assertEquals([0, 1], array_keys($monthCounts['totals']));
+        static::assertSame([0, 1], array_keys($monthCounts['totals']));
 
         // Labels for the months
-        static::assertEquals(
+        static::assertSame(
             ['2016-12', '2017-01', '2017-02', '2017-03', '2017-04'],
             $monthCounts['monthLabels']
         );
 
         // Labels for the years
-        static::assertEquals(['2016', '2017'], $monthCounts['yearLabels']);
+        static::assertSame(['2016', '2017'], $monthCounts['yearLabels']);
 
         // Month counts by namespace.
         $monthsWithNamespaces = $this->editCounter->monthCountsWithNamespaces($mockTime);
-        static::assertEquals(
+        static::assertSame(
             $monthCounts['monthLabels'],
             array_keys($monthsWithNamespaces)
         );
-        static::assertEquals([0, 1], array_keys($monthsWithNamespaces['2017-03']));
-
-        // Month totals.
-        $monthTotals = $this->editCounter->monthTotals($mockTime);
-        static::assertEquals(
-            [
-                '2016-12' => 10,
-                '2017-01' => 0,
-                '2017-02' => 50,
-                '2017-03' => 20,
-                '2017-04' => 0,
-            ],
-            $monthTotals
-        );
+        static::assertSame([0, 1], array_keys($monthsWithNamespaces['2017-03']));
 
         $yearTotals = $this->editCounter->yearTotals($mockTime);
-        static::assertEquals(['2016' => 10, '2017' => 70], $yearTotals);
+        static::assertSame(['2016' => 10, '2017' => 70], $yearTotals);
     }
 
     /**
@@ -368,8 +353,7 @@ class EditCounterTest extends TestAdapter
         // Mock current time by passing it in (dummy parameter, so to speak).
         $yearCounts = $this->editCounter->yearCounts(new DateTime('2017-04-30 23:59:59'));
 
-        // Make sure zeros were filled in for months with no edits,
-        //   and for each namespace.
+        // Make sure zeros were filled in for months with no edits, and for each namespace.
         static::assertArraySubset(
             [
                 2015 => 0,

--- a/tests/Model/EditSummaryTest.php
+++ b/tests/Model/EditSummaryTest.php
@@ -38,16 +38,10 @@ class EditSummaryTest extends TestAdapter
         $userRepo = $this->createMock(UserRepository::class);
         $this->user = new User($userRepo, 'Test user');
         $editSummaryRepo = $this->createMock(EditSummaryRepository::class);
-        $session = $this->createSession(static::createClient());
-        $ti18nHelper = new I18nHelper(
-            $this->getRequestStack($session),
-            static::getContainer()->getParameter('kernel.project_dir')
-        );
         $this->editSummary = new EditSummary(
             $editSummaryRepo,
             $this->project,
             $this->user,
-            $ti18nHelper,
             'all',
             false,
             false,

--- a/tests/Model/EditTest.php
+++ b/tests/Model/EditTest.php
@@ -250,11 +250,12 @@ class EditTest extends TestAdapter
         $edit = $this->getEditFactory();
         static::assertEquals(
             [
+                'project' => 'en.wikipedia.org',
                 'username' => 'Testuser',
-                'page_title' => 'Test_page',
+                'page_title' => 'Test page',
                 'namespace' => $this->page->getNamespace(),
                 'rev_id' => 1,
-                'timestamp' => '2017-01-01T10:00:00',
+                'timestamp' => '2017-01-01T10:00:00Z',
                 'minor' => false,
                 'length' => 12,
                 'length_change' => 2,

--- a/tests/Model/TopEditsTest.php
+++ b/tests/Model/TopEditsTest.php
@@ -109,10 +109,10 @@ class TopEditsTest extends TestAdapter
         static::assertEquals(2, count($result[3]));
         static::assertEquals([
             'namespace' => '0',
-            'page_title' => 'Foo_bar',
+            'page_title' => 'Foo bar',
             'redirect' => '1',
             'count' => '24',
-            'full_page_title' => 'Foo_bar',
+            'full_page_title' => 'Foo bar',
             'assessment' => [
                 'class' => 'List',
             ],
@@ -143,10 +143,10 @@ class TopEditsTest extends TestAdapter
         static::assertEquals(2, count($result[3]));
         static::assertEquals([
             'namespace' => '3',
-            'page_title' => 'Jimbo_Wales',
+            'page_title' => 'Jimbo Wales',
             'redirect' => '0',
             'count' => '1',
-            'full_page_title' => 'User_talk:Jimbo_Wales',
+            'full_page_title' => 'User talk:Jimbo Wales',
         ], $result[3][1]);
     }
 


### PR DESCRIPTION
This implements the changes that were announced in XTools 3.19

Make EC month counts be grouped by YYYY-MM