### PR TITLE
Fix contrast of gray text in pageInfo API HTML response

### DIFF
--- a/templates/pageInfo/api.html.twig
+++ b/templates/pageInfo/api.html.twig
@@ -7,7 +7,7 @@
         -#}{{ data.revisions|num_format }} {{ msg('num-revisions', [data.revisions]) }}{{ msg('comma-character') }}
     {% else %}{#-
         -#}{{ msg('num-revisions-since', [data.revisions|num_format, data.revisions, "<a target='_blank' href='" ~ wiki.pageUrlRaw('Special:PermaLink/' ~ data.created_rev_id, project) ~ "'>" ~ data.created_at|date_format('yyyy-MM-dd') ~ "</a>"]) }}
-        <span style="color:#A2A9B1">(<a href="{{ wiki.pageUrlRaw('Special:Diff/' ~ data.modified_rev_id, project) }}" style="color:#A2A9B1">+{{ formatDuration(data.secs_since_last_edit) }}</a>)</span>{{ msg('comma-character') }}
+        <span style="color: var(--color-subtle, #54595d);">(<a href="{{ wiki.pageUrlRaw('Special:Diff/' ~ data.modified_rev_id, project) }}" style="color: inherit;">+{{ formatDuration(data.secs_since_last_edit) }}</a>)</span>{{ msg('comma-character') }}
         {{ data.editors|num_format }} {{ msg('num-editors', [data.editors]) }}{{ msg('comma-character') }}
     {% endif %}
 {% endif %}


### PR DESCRIPTION
![image](https://github.com/x-tools/xtools/assets/33615628/e4eb6313-8f90-40c9-9569-627bc52c796f)

#a2a9b1 [doesn't](https://www.siegemedia.com/contrast-ratio#%23fff-on-%23a2a9b1) have an appropriate contrast ratio with the white background. Use a color intended for secondary text, and while we're at it, use a CSS variable available in dark mode (I assume this HTML is supposed to be used in MediaWiki context, but if it is not, the color will fall back to #54595d).