### PR TITLE
EditCounter: show number of active blocks instead of the expiry

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -67,7 +67,7 @@
 	"blame-as-of-desc": "Use this to perform a blame search on older versions of the article.",
 	"blame-query-desc": "Search query should include any underlying wikitext.",
 	"block": "Block",
-	"block-current": "Current block",
+	"block-current-count": "Current blocks",
 	"block-log": "Block log",
 	"block-longest": "Longest block",
 	"blocks": "Blocks",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -86,7 +86,7 @@
 	"blame-as-of-desc": "Tooltip indicating what the 'as of' option does. It allows you to search 'as of' different revisions, in order to find edits that added wikitext that does not exist in the current version of the article.",
 	"blame-query-desc": "Tooltip indicating that the search query for the Blame tool should be wikitext, and not necessarily a direct copy/paste of visible content that you want to search for.",
 	"block": "Name of a MediaWiki log action, used as header of a row in the table of log action counts for a user.\n{{Identical|Block}}",
-	"block-current": "Label for info about a user's current block.",
+	"block-current-count": "Label for number of blocks currently placed on a user.",
 	"block-log": "Link to a user's block log.\n{{Identical|Block log}}",
 	"block-longest": "Label for info about the longest block a user received.",
 	"blocks": "Heading for section listing stats about a user's block log.\n{{Identical|Block}}",

--- a/src/Model/User.php
+++ b/src/Model/User.php
@@ -381,24 +381,13 @@ class User extends Model
     }
 
     /**
-     * Get the expiry of the current block on the user
+     * Get the number of active blocks on the user.
      * @param Project $project The project.
-     * @return DateTime|bool Expiry as DateTime, true if indefinite, or false if they are not blocked.
+     * @return int Number of active blocks.
      */
-    public function getBlockExpiry(Project $project)
+    public function countActiveBlocks(Project $project): int
     {
-        $expiry = $this->repository->getBlockExpiry(
-            $project->getDatabaseName(),
-            $this->getUsername()
-        );
-
-        if ('infinity' === $expiry) {
-            return true;
-        } elseif (false === $expiry) {
-            return false;
-        } else {
-            return new DateTime($expiry);
-        }
+        return (int)$this->repository->countActiveBlocks($project, $this);
     }
 
     /**
@@ -408,7 +397,7 @@ class User extends Model
      */
     public function isBlocked(Project $project): bool
     {
-        return false !== $this->getBlockExpiry($project);
+        return $this->countActiveBlocks($project) > 0;
     }
 
     /**

--- a/templates/editCounter/general_stats.html.twig
+++ b/templates/editCounter/general_stats.html.twig
@@ -228,16 +228,12 @@
             </td>
         </tr>
         <tr>
-            <td>{{ msg('block-current') }}</td>
+            <td>{{ msg('block-current-count') }}</td>
             <td>
                 {% if user.isBlocked(project) %}
                     <a href="{{ wiki.pageUrlRaw('Special:BlockList', project)~'?wpTarget='~user.username }}">{% apply spaceless %}
-                            {% if user.getBlockExpiry(project) == 'infinity' %}
-                                &#x221e; {# infinity #}
-                            {% else %}
-                                {{ user.getBlockExpiry(project)|date_format }}
-                            {% endif %}
-                        {% endapply %}</a>
+                        {{ user.countActiveBlocks(project, user)|num_format }}
+                    {% endapply %}</a>
                 {% else %}
                     &ndash;
                 {% endif %}

--- a/templates/editCounter/general_stats.wikitext.twig
+++ b/templates/editCounter/general_stats.wikitext.twig
@@ -212,12 +212,8 @@
 | {% if ec.longestBlockSeconds == -1 %}&#x221e; {# infinity #}{% elseif ec.longestBlockSeconds == false %}&ndash;{% else %}{{ formatDuration(ec.longestBlockSeconds) }}{% endif %}
 
 |-
-| {{ msg('block-current') }}
-| {% if user.isBlocked(project) %}[[Special:BlockList/{{ user.username }}|{% apply spaceless %}
-    {% if user.getBlockExpiry(project) == 'infinity' %}&#x221e;{# infinity #}{% else %}
-        {{ user.getBlockExpiry(project)|date_format }}{% endif %}]]
-{% endapply %}
-
+| {{ msg('block-current-count') }}
+| {% if user.isBlocked(project) %}[[Special:BlockList/{{ user.username }}|{{ user.countActiveBlocks(project, user)|num_format }}]]
 {% else %}&ndash;
 {% endif %}
 |-

--- a/tests/Model/UserTest.php
+++ b/tests/Model/UserTest.php
@@ -91,18 +91,18 @@ class UserTest extends TestAdapter
     /**
      * Get the expiry of the current block of a user on a given project
      */
-    public function testExpiry(): void
+    public function testCountActiveBlocks(): void
     {
         $this->userRepo->expects($this->once())
-            ->method('getBlockExpiry')
-            ->willReturn('20500601000000');
+            ->method('countActiveBlocks')
+            ->willReturn(5);
         $user = new User($this->userRepo, 'TestUser');
 
         $projectRepo = $this->createMock(ProjectRepository::class);
         $project = new Project('wiki.example.org');
         $project->setRepository($projectRepo);
 
-        static::assertEquals(new DateTime('20500601000000'), $user->getBlockExpiry($project));
+        static::assertEquals(5, $user->countActiveBlocks($project));
     }
 
     /**
@@ -111,8 +111,8 @@ class UserTest extends TestAdapter
     public function testIsBlocked(): void
     {
         $this->userRepo->expects($this->once())
-            ->method('getBlockExpiry')
-            ->willReturn('infinity');
+            ->method('countActiveBlocks')
+            ->willReturn(1);
         $user = new User($this->userRepo, 'TestUser');
 
         $projectRepo = $this->createMock(ProjectRepository::class);


### PR DESCRIPTION
Multiblocks is coming soon and thus there may be multiple expiries. In addition, it was discovered the new `block_target.bt_user_text` field is very slow to query on. So, we'll instead simply show the number of active blocks and link to Special:BlockList. Also cache the query.

Bug: T391824