### PR TITLE
Display time order correctly in RTL wikis

### DIFF
--- a/templates/pageInfo/api.html.twig
+++ b/templates/pageInfo/api.html.twig
@@ -6,7 +6,7 @@
     {% if data.created_at is empty %}{#-
         -#}{{ data.revisions|num_format }} {{ msg('num-revisions', [data.revisions]) }}{{ msg('comma-character') }}
     {% else %}{#-
-        -#}{{ msg('num-revisions-since', [data.revisions|num_format, data.revisions, "<a target='_blank' href='" ~ wiki.pageUrlRaw('Special:PermaLink/' ~ data.created_rev_id, project) ~ "'>" ~ data.created_at|date_format('yyyy-MM-dd') ~ "</a>"]) }}
+        -#}{{ msg('num-revisions-since', [data.revisions|num_format, data.revisions, "<bdi><a target='_blank' href='" ~ wiki.pageUrlRaw('Special:PermaLink/' ~ data.created_rev_id, project) ~ "'>" ~ data.created_at|date_format('yyyy-MM-dd') ~ "</a></bdi>"]) }}
         <span style="color: var(--color-subtle, #54595d);">(<a href="{{ wiki.pageUrlRaw('Special:Diff/' ~ data.modified_rev_id, project) }}" style="color: inherit;">+{{ formatDuration(data.secs_since_last_edit) }}</a>)</span>{{ msg('comma-character') }}
         {{ data.editors|num_format }} {{ msg('num-editors', [data.editors]) }}{{ msg('comma-character') }}
     {% endif %}


### PR DESCRIPTION
This turns

<img width="247" alt="image" src="https://github.com/user-attachments/assets/dc6571aa-605c-4a46-9287-c41affdd7033" />

to 

<img width="279" alt="image" src="https://github.com/user-attachments/assets/8636a4a6-1b84-4ed3-bfe5-e985d6d43bd3" />

in RTL wikis but `<bdi>` wouldn't hurt the use in LTR wikis also.