### PR TITLE
Adapt better to invalid language codes

### DIFF
--- a/src/Controller/XtoolsController.php
+++ b/src/Controller/XtoolsController.php
@@ -269,6 +269,13 @@ abstract class XtoolsController extends AbstractController
 
         // Check if the request is to a restricted API endpoint, where the target user has to opt-in to statistics.
         $this->checkRestrictedApiEndpoint();
+
+        // Give the i18n helper access to flashes.
+        $this->i18n->setFlash(
+            function (string $type, $msg) {
+                return $this->addFlash($type, $msg);
+            }
+        );
     }
 
     /**

--- a/src/Helper/I18nHelper.php
+++ b/src/Helper/I18nHelper.php
@@ -306,17 +306,6 @@ class I18nHelper
     }
 
     /**
-     * Check if we have a file for a language code.
-     * @param string langCode
-     * @return bool
-     */
-    private function checkLanguageFile($langCode): bool
-    {
-        $path = $this->projectDir . '/i18n';
-        return file_exists("$path/$langCode.json");
-    }
-
-    /**
      * Determine the interface language, either from the current request or session.
      * @return string
      */

--- a/src/Helper/I18nHelper.php
+++ b/src/Helper/I18nHelper.php
@@ -329,7 +329,7 @@ class I18nHelper
             $tempLang = 'en';
         }
 
-        return $tempLang
+        return $tempLang;
     }
 
     /**

--- a/src/Helper/I18nHelper.php
+++ b/src/Helper/I18nHelper.php
@@ -291,6 +291,17 @@ class I18nHelper
     }
 
     /**
+     * Check if we have a file for a language code.
+     * @param string langCode
+     * @return bool
+     */
+    private function checkLanguageFile($langCode): bool
+    {
+        $path = $this->projectDir . '/i18n';
+        return file_exists("$path/$langCode.json");
+    }
+
+    /**
      * Determine the interface language, either from the current request or session.
      * @return string
      */
@@ -299,9 +310,9 @@ class I18nHelper
         $queryLang = $this->getRequest()->query->get('uselang');
         $sessionLang = $this->requestStack->getSession()->get('lang');
 
-        if ('' !== $queryLang && null !== $queryLang) {
+        if ('' !== $queryLang && null !== $queryLang && $this->checkLanguageFile($queryLang)) {
             return $queryLang;
-        } elseif ('' !== $sessionLang && null !== $sessionLang) {
+        } elseif ('' !== $sessionLang && null !== $sessionLang && $this->checkLanguageFile($sessionLang)) {
             return $sessionLang;
         }
 

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -251,7 +251,7 @@ class TopEditsRepository extends UserRepository
                 FROM
                 (
                     SELECT b.page_namespace, b.page_is_redirect, b.rev_page, b.count
-                        ,@rn := if(@ns = b.page_namespace, @rn + 1, 1) AS row_number
+                        ,@rn := if(@ns = b.page_namespace, @rn + 1, 1) AS `row_number`
                         ,@ns := b.page_namespace AS dummy
                     FROM
                     (
@@ -267,7 +267,7 @@ class TopEditsRepository extends UserRepository
                     ORDER BY b.page_namespace ASC, b.count DESC
                 ) AS c
                 JOIN $pageTable e ON e.page_id = c.rev_page
-                WHERE c.row_number <= $limit";
+                WHERE c.`row_number` <= $limit";
         $resultQuery = $this->executeQuery($sql, $project, $user, 'all', $params);
         $result = $resultQuery->fetchAllAssociative();
 


### PR DESCRIPTION
Namely, fall back to `en` earlier (in `getIntuitionLang`) if Intuition says this isn't a valid language code, and flash to the user that it isn't. Because `$.i18n` (used in charts and a few other places) crashes when fed an invalid language code.

Bug: T393736