### PR TITLE
EditCounter: integrate flaggedrevs in protection counts

### DIFF
--- a/src/Model/EditCounter.php
+++ b/src/Model/EditCounter.php
@@ -459,7 +459,8 @@ class EditCounter extends Model
     public function countPagesProtected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-protect'] ?? 0;
+        return $logCounts['protect-protect']
+            + $logCounts['stable-config'];
     }
 
     /**
@@ -469,7 +470,9 @@ class EditCounter extends Model
     public function countPagesReprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-modify'] ?? 0;
+        return $logCounts['protect-modify']
+            + $logCounts['stable-modify']
+            + $logCounts['stable-move_stable'];
     }
 
     /**
@@ -479,7 +482,8 @@ class EditCounter extends Model
     public function countPagesUnprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-unprotect'] ?? 0;
+        return $logCounts['protect-unprotect']
+            + $logCounts['stable-reset'];
     }
 
     /**

--- a/src/Model/EditCounter.php
+++ b/src/Model/EditCounter.php
@@ -459,8 +459,8 @@ class EditCounter extends Model
     public function countPagesProtected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-protect'] ?? 0
-            + $logCounts['stable-config'] ?? 0;
+        return ($logCounts['protect-protect'] ?? 0)
+            + ($logCounts['stable-config'] ?? 0);
     }
 
     /**
@@ -470,9 +470,9 @@ class EditCounter extends Model
     public function countPagesReprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-modify'] ?? 0
-            + $logCounts['stable-modify'] ?? 0
-            + $logCounts['stable-move_stable'] ?? 0;
+        return ($logCounts['protect-modify'] ?? 0)
+            + ($logCounts['stable-modify'] ?? 0)
+            + ($logCounts['stable-move_stable'] ?? 0);
     }
 
     /**
@@ -482,8 +482,8 @@ class EditCounter extends Model
     public function countPagesUnprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-unprotect'] ?? 0
-            + $logCounts['stable-reset'] ?? 0;
+        return ($logCounts['protect-unprotect'] ?? 0)
+            + ($logCounts['stable-reset'] ?? 0);
     }
 
     /**

--- a/src/Model/EditCounter.php
+++ b/src/Model/EditCounter.php
@@ -471,8 +471,7 @@ class EditCounter extends Model
     {
         $logCounts = $this->getLogCounts();
         return ($logCounts['protect-modify'] ?? 0)
-            + ($logCounts['stable-modify'] ?? 0)
-            + ($logCounts['stable-move_stable'] ?? 0);
+            + ($logCounts['stable-modify'] ?? 0);
     }
 
     /**

--- a/src/Model/EditCounter.php
+++ b/src/Model/EditCounter.php
@@ -459,8 +459,8 @@ class EditCounter extends Model
     public function countPagesProtected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-protect']
-            + $logCounts['stable-config'];
+        return $logCounts['protect-protect'] ?? 0
+            + $logCounts['stable-config'] ?? 0;
     }
 
     /**
@@ -470,9 +470,9 @@ class EditCounter extends Model
     public function countPagesReprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-modify']
-            + $logCounts['stable-modify']
-            + $logCounts['stable-move_stable'];
+        return $logCounts['protect-modify'] ?? 0
+            + $logCounts['stable-modify'] ?? 0
+            + $logCounts['stable-move_stable'] ?? 0;
     }
 
     /**
@@ -482,8 +482,8 @@ class EditCounter extends Model
     public function countPagesUnprotected(): int
     {
         $logCounts = $this->getLogCounts();
-        return $logCounts['protect-unprotect']
-            + $logCounts['stable-reset'];
+        return $logCounts['protect-unprotect'] ?? 0
+            + $logCounts['stable-reset'] ?? 0;
     }
 
     /**

--- a/src/Repository/EditCounterRepository.php
+++ b/src/Repository/EditCounterRepository.php
@@ -213,7 +213,6 @@ class EditCounterRepository extends Repository
             'stable-config',
             'stable-reset',
             'stable-modify',
-            'stable-move_stable',
         ];
         foreach ($requiredCounts as $req) {
             if (!isset($logCounts[$req])) {

--- a/src/Repository/EditCounterRepository.php
+++ b/src/Repository/EditCounterRepository.php
@@ -210,6 +210,10 @@ class EditCounterRepository extends Repository
             'pagetriage-curation-reviewed',
             'pagetriage-curation-reviewed-redirect',
             'pagetriage-curation-reviewed-article',
+            'stable-config',
+            'stable-reset',
+            'stable-modify',
+            'stable-move_stable',
         ];
         foreach ($requiredCounts as $req) {
             if (!isset($logCounts[$req])) {

--- a/tests/Model/EditCounterTest.php
+++ b/tests/Model/EditCounterTest.php
@@ -80,7 +80,6 @@ class EditCounterTest extends TestAdapter
                 // intentionally does not include 'protect-protect'
                 'protect-modify' => 5,
                 'protect-unprotect' => 6,
-                
                 'delete-revision' => 7,
                 'upload-upload' => 8,
                 // intentionally does not include 'delete-event'

--- a/tests/Model/EditCounterTest.php
+++ b/tests/Model/EditCounterTest.php
@@ -80,6 +80,7 @@ class EditCounterTest extends TestAdapter
                 // intentionally does not include 'protect-protect'
                 'protect-modify' => 5,
                 'protect-unprotect' => 6,
+                
                 'delete-revision' => 7,
                 'upload-upload' => 8,
                 // intentionally does not include 'delete-event'


### PR DESCRIPTION
Of course, FlaggedRevs' documentation is not much to go on, but from logs and quarry &c it looks like there are four actions of type `stable`:
 - `config`: apparently sets pending changes, so I bundled it in protection
 - `modify`: obviously goes with reprotection
 - `move_stable`: bundled it too with reprotection
 - `reset`: I'm pretty sure this is unprotection.

Bug: T284876