### PR TITLE
TopEdits: add pages edited counts to results_namespace

### DIFF
--- a/templates/topedits/result_namespace.html.twig
+++ b/templates/topedits/result_namespace.html.twig
@@ -22,6 +22,7 @@
     {% for ns, pages in te.topEdits %}
         {% set showPageAssessment = project.hasPageAssessments(ns) %}
         {% set content %}
+        <p>{{ te.numPagesNamespace(ns) }} {{ msg('pages')|lower }}.</p>
         <table class="table table-bordered table-hover table-striped topedits-namespace-table xt-show-hide--target">
             <thead><tr>
                 <th>

--- a/templates/topedits/result_namespace.wikitext.twig
+++ b/templates/topedits/result_namespace.wikitext.twig
@@ -15,6 +15,7 @@
 ==== {{ nsName(ns, project.namespaces) }} ====
 
 {% set showPageAssessment = ns == 0 and project.hasPageAssessments %}
+{{ te.numPagesNamespace(ns) }} {{ msg('pages')|lower }}.
 {| class="wikitable sortable"
 ! {{ msg('edits')|ucfirst }}
 ! {{ msg('page-title') }}


### PR DESCRIPTION
Luckily, we already had a function in place in Model and Repo (it's used to compute the number of "pages" for result pagination.)

Bug: T218531