### PR TITLE
Fix error messages and codes for timeouts

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -144,6 +144,7 @@
 	"error-login": "Login failed! Please try again.",
 	"error-login-required": "For performance reasons, the requested data is only available to logged-in users.",
 	"error-login-required-link": "Please login to continue.",
+	"error-lost-connection": "The database connection was lost. It was likely stopped by the server, which indicates that too much data was requested.",
 	"error-pageinfo-api": "Unable to fetch revision data.",
 	"error-pagepile-too-large": "Sorry, there are too many pages to export to PagePile. You can manually create a PagePile, or try narrowing down the result set by limiting to a specific namespace or time frame.",
 	"error-param": "'$1' is not a valid value for the '$2' parameter",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -163,6 +163,7 @@
 	"error-login": "Error shown when logging in failed.",
 	"error-login-required": "Error shown when the user must be logged in to use the tool.",
 	"error-login-required-link": "Link text for logging in when the user must be logged in to use the tool.",
+	"error-lost-connection": "Error message shown for when the database connection was lost.",
 	"error-pageinfo-api": "Error shown when the PageInfo API was unable to fetch any data about the revisions to the page.",
 	"error-pagepile-too-large": "Error shown when a PagePile could not be created from the Pages Created tool. PagePile is another tool used to make lists of pages. In some cases we can't create a PagePile because there are too many pages.",
 	"error-param": "Error shown when an invalid value is passed for a parameter.",

--- a/src/EventSubscriber/ExceptionListener.php
+++ b/src/EventSubscriber/ExceptionListener.php
@@ -144,7 +144,7 @@ class ExceptionListener
 
         return new Response(
             $this->templateEngine->render('bundles/TwigBundle/Exception/error.html.twig', [
-                'status_code' => Response::HTTP_INTERNAL_SERVER_ERROR,
+                'status_code' => $exception->getCode(),
                 'status_text' => 'Internal Server Error',
                 'exception' => $exception,
             ]),

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -423,9 +423,21 @@ abstract class Repository
             throw new ServiceUnavailableHttpException(30, 'error-service-overload', null, 503);
         } elseif (in_array($e->getErrorCode(), [2006, 2013])) {
             // FIXME: Attempt to reestablish connection on 2006 error (MySQL server has gone away).
-            throw new HttpException(Response::HTTP_GATEWAY_TIMEOUT, 'error-lost-connection', null, [], Response::HTTP_GATEWAY_TIMEOUT);
-        } elseif ($e->getErrorCode() === 1969) {
-            throw new HttpException(Response::HTTP_GATEWAY_TIMEOUT, 'error-query-timeout', null, [$timeout], Response::HTTP_GATEWAY_TIMEOUT);
+            throw new HttpException(
+                Response::HTTP_GATEWAY_TIMEOUT,
+                'error-lost-connection',
+                null,
+                [],
+                Response::HTTP_GATEWAY_TIMEOUT
+            );
+        } elseif (1969 == $e->getErrorCode()) {
+            throw new HttpException(
+                Response::HTTP_GATEWAY_TIMEOUT,
+                'error-query-timeout',
+                null,
+                [$timeout],
+                Response::HTTP_GATEWAY_TIMEOUT
+            );
         } else {
             throw $e;
         }

--- a/src/Repository/Repository.php
+++ b/src/Repository/Repository.php
@@ -421,9 +421,11 @@ abstract class Repository
 
         if (1226 === $e->getErrorCode()) {
             throw new ServiceUnavailableHttpException(30, 'error-service-overload', null, 503);
-        } elseif (in_array($e->getErrorCode(), [1969, 2006, 2013])) {
+        } elseif (in_array($e->getErrorCode(), [2006, 2013])) {
             // FIXME: Attempt to reestablish connection on 2006 error (MySQL server has gone away).
-            throw new HttpException(Response::HTTP_GATEWAY_TIMEOUT, 'error-query-timeout', null, [], $timeout);
+            throw new HttpException(Response::HTTP_GATEWAY_TIMEOUT, 'error-lost-connection', null, [], Response::HTTP_GATEWAY_TIMEOUT);
+        } elseif ($e->getErrorCode() === 1969) {
+            throw new HttpException(Response::HTTP_GATEWAY_TIMEOUT, 'error-query-timeout', null, [$timeout], Response::HTTP_GATEWAY_TIMEOUT);
         } else {
             throw $e;
         }

--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -21,12 +21,13 @@
         {% else %}
             {% set message = 'unknown' %}
         {% endif %}
-
         {% if exception.class is defined and exception.class == 'BadGatewayException' %}
             {# We ignore 502s as we can't fix them, so there's no need to add a link to report it as a bug. #}
             <p>{{ msg(message, [exception.msgParams]) }}</p>
-        {% elseif msgExists(message, [exception.code]) %}
-            <p><strong>{{ msg(message, [exception.code]) }}</strong></p>
+        {% elseif exception.headers is defined and (not exception.headers is empty) and msgExists(message, [exception.headers[0]]) %}
+            <p><strong>{{ msg(message, [exception.headers[0]]) }}</strong></p>
+        {% elseif msgExists(message) %}
+            <p><strong>{{ msg(message) }}</strong></p>
         {% elseif exception.code == 999 %}
             {# This is a server-built message ready to be displayed that can safely use raw() #}
             <p>{{ message|raw }}</p>


### PR DESCRIPTION
Split messages depending on whether we or the server stopped the request.
Fix a helper function returning 500 in all cases.
Fix the timeout being stored where the status code should go.

Bug: T226307