### PR TITLE
PageInfoApi: remove table extension to get rows with deleted actor

### DIFF
--- a/src/Repository/PageInfoRepository.php
+++ b/src/Repository/PageInfoRepository.php
@@ -297,7 +297,8 @@ class PageInfoRepository extends AutoEditsRepository
 
         $project = $page->getProject();
         $revTable = $project->getTableName('revision');
-        $revWithoutExtension = $project->getTableName('revision', ''); // Needed because userindex is missing some revdeleted rows
+        // Needed because userindex is missing some revdeleted rows
+        $revWithoutExtension = $project->getTableName('revision', '');
         $userTable = $project->getTableName('user');
         $pageTable = $project->getTableName('page');
         $actorTable = $project->getTableName('actor');

--- a/src/Repository/PageInfoRepository.php
+++ b/src/Repository/PageInfoRepository.php
@@ -297,6 +297,7 @@ class PageInfoRepository extends AutoEditsRepository
 
         $project = $page->getProject();
         $revTable = $project->getTableName('revision');
+        $revWithoutExtension = $project->getTableName('revision', ''); // Needed because userindex is missing some revdeleted rows
         $userTable = $project->getTableName('user');
         $pageTable = $project->getTableName('page');
         $actorTable = $project->getTableName('actor');
@@ -333,7 +334,7 @@ class PageInfoRepository extends AutoEditsRepository
                     (
                         SELECT rev_timestamp AS modified_at,
                                rev_id AS modified_rev_id
-                        FROM $revTable
+                        FROM $revWithoutExtension
                         JOIN $pageTable ON page_id = rev_page
                         WHERE rev_page = :pageid
                         AND rev_id = page_latest


### PR DESCRIPTION
We were using `userindex` when we didn't need to; `userindex` skips rows with revdeleted actors; so it didn't have `page_latest`; and the whole thing came crashing down. So the solution is just don't use userindex for that subquery.

Bug: T376210