### PR TITLE
TopEdits: limit per ns in php not sql, assigment errorring in prod

### DIFF
--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -218,7 +218,7 @@ class TopEditsRepository extends UserRepository
     ): array {
         // Set up cache.
         $cacheKey = $this->getCacheKey(func_get_args(), 'topedits_all');
-        if ($this->cache->hasItem($cacheKey) && false) {
+        if ($this->cache->hasItem($cacheKey)) {
             return $this->cache->getItem($cacheKey)->get();
         }
 

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -279,8 +279,6 @@ class TopEditsRepository extends UserRepository
                 $filteredResult[] = $object;
             }
         }
-        $this->logger->error(json_encode($result));
-        $this->logger->error(json_encode($filteredResult));
 
         // Cache and return.
         return $this->setCache($cacheKey, $filteredResult);


### PR DESCRIPTION
Shouldn't be slower, given we already query all the data. Fixes a prod error happening at commons and other projects.

I don't know why the error happens, but it's related to the assignments; at least this gives a fix while we investigate.

Bug: T396423