### PR TITLE
TopEdits: prepare data only if user opted in

### DIFF
--- a/src/Model/TopEdits.php
+++ b/src/Model/TopEdits.php
@@ -184,6 +184,10 @@ class TopEdits extends Model
      */
     public function prepareData(): void
     {
+        if (!$this->project->userHasOptedIn($this->user)) {
+            $this->topEdits = [];
+            return;
+        }
         if (isset($this->page)) {
             $this->topEdits = $this->getTopEditsPage();
         } else {

--- a/tests/Model/TopEditsTest.php
+++ b/tests/Model/TopEditsTest.php
@@ -45,6 +45,9 @@ class TopEditsTest extends TestAdapter
             ->willReturn(['namespaces' => [0 => 'Main', 3 => 'User_talk']]);
         $this->projectRepo->method('getOne')
             ->willReturn(['url' => 'https://en.wikipedia.org']);
+        $this->projectRepo->method('pageHasContent')
+            ->with($this->project, 2, 'Test user/EditCounterOptIn.js')
+            ->willReturn(true);
         $this->project->setRepository($this->projectRepo);
         $this->userRepo = $this->createMock(UserRepository::class);
         $this->user = new User($this->userRepo, 'Test user');


### PR DESCRIPTION
Else we're making queries for nothing.

Bug: T396494