### PR TITLE
TopEdits: limit in sql not php to avoid memory issue

### DIFF
--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -251,6 +251,8 @@ class TopEditsRepository extends UserRepository
                 FROM
                 (
                     SELECT b.page_namespace, b.page_is_redirect, b.rev_page, b.count
+                        ,@rn := if(@ns = b.page_namespace, @rn + 1, 1) AS `row_number`
+                        ,@ns := b.page_namespace AS dummy
                     FROM
                     (
                         SELECT page_namespace, page_is_redirect, rev_page, count(rev_page) AS count
@@ -264,21 +266,10 @@ class TopEditsRepository extends UserRepository
                     JOIN (SELECT @ns := NULL, @rn := 0) AS vars
                     ORDER BY b.page_namespace ASC, b.count DESC
                 ) AS c
-                JOIN $pageTable e ON e.page_id = c.rev_page";
+                JOIN $pageTable e ON e.page_id = c.rev_page
+                WHERE c.`row_number` <= $limit";
         $resultQuery = $this->executeQuery($sql, $project, $user, 'all', $params);
         $result = $resultQuery->fetchAllAssociative();
-        $namespaceCounts = [];
-        $filteredResult = [];
-        foreach ($result as $object) {
-            if (isset($namespaceCounts[$object['namespace']])) {
-                $namespaceCounts[$object['namespace']] += 1;
-            } else {
-                $namespaceCounts[$object['namespace']] = 1;
-            }
-            if ($namespaceCounts[$object['namespace']] <= $limit) {
-                $filteredResult[] = $object;
-            }
-        }
 
         // Cache and return.
         return $this->setCache($cacheKey, $filteredResult);

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -272,7 +272,7 @@ class TopEditsRepository extends UserRepository
         $result = $resultQuery->fetchAllAssociative();
 
         // Cache and return.
-        return $this->setCache($cacheKey, $filteredResult);
+        return $this->setCache($cacheKey, $result);
     }
 
     /**


### PR DESCRIPTION
Largely a revert of #547 , plus backticks. I then didn't take into account the fact that limiting in PHP not SQL was going to put a boatload of stuff in memory. Was causing memory shortages for TE for users that created many pages. Plus, now we know that the real problem wasn't the assignments (`:=`) but `row_number` having become reserved in MariaDB 10.7; therefore, just revert to previous code, and backtick that.