### PR TITLE
PageInfo: remove checks for Wikidata errors

### DIFF
--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -376,50 +376,7 @@ class Page extends Model
     }
 
     /**
-     * Get Wikidata errors for this page
-     * @return string[][] See getErrors() for format
-     */
-    public function getWikidataErrors(): array
-    {
-        $errors = [];
-
-        if (empty($this->getWikidataId())) {
-            return [];
-        }
-
-        $wikidataInfo = $this->repository->getWikidataInfo($this);
-
-        $terms = array_map(function ($entry) {
-            return $entry['term'];
-        }, $wikidataInfo);
-
-        $lang = $this->getLang();
-
-        if (!in_array('label', $terms)) {
-            $errors[] = [
-                'prio' => 2,
-                'name' => 'Wikidata',
-                'notice' => "Label for language <em>$lang</em> is missing", // FIXME: i18n
-                'explanation' => "See: <a target='_blank' " .
-                    "href='//www.wikidata.org/wiki/Help:Label'>Help:Label</a>",
-            ];
-        }
-
-        if (!in_array('description', $terms)) {
-            $errors[] = [
-                'prio' => 3,
-                'name' => 'Wikidata',
-                'notice' => "Description for language <em>$lang</em> is missing", // FIXME: i18n
-                'explanation' => "See: <a target='_blank' " .
-                    "href='//www.wikidata.org/wiki/Help:Description'>Help:Description</a>",
-            ];
-        }
-
-        return $errors;
-    }
-
-    /**
-     * Get Wikidata and CheckWiki errors, if present
+     * Get CheckWiki errors, if present
      * @return string[][] List of errors in the format:
      *    [[
      *         'prio' => int,
@@ -430,12 +387,7 @@ class Page extends Model
      */
     public function getErrors(): array
     {
-        // Includes label and description
-        $wikidataErrors = $this->getWikidataErrors();
-
-        $checkWikiErrors = $this->getCheckWikiErrors();
-
-        return array_merge($wikidataErrors, $checkWikiErrors);
+        return $this->getCheckWikiErrors();
     }
 
     /**

--- a/src/Model/PageInfoApi.php
+++ b/src/Model/PageInfoApi.php
@@ -47,7 +47,7 @@ class PageInfoApi extends Model
     /** @var string[]|null Assessments of the page (see Page::getAssessments). */
     protected ?array $assessments;
 
-    /** @var string[] List of Wikidata and Checkwiki errors. */
+    /** @var string[] List of Checkwiki errors. */
     protected array $bugs;
 
     /**
@@ -250,7 +250,7 @@ class PageInfoApi extends Model
     }
 
     /**
-     * Get the list of page's wikidata and Checkwiki errors.
+     * Get the list of page's Checkwiki errors.
      * @see Page::getErrors()
      * @return string[]
      */
@@ -263,7 +263,7 @@ class PageInfoApi extends Model
     }
 
     /**
-     * Get the number of wikidata nad CheckWiki errors.
+     * Get the number of CheckWiki errors.
      * @return int
      */
     public function numBugs(): int

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -258,41 +258,6 @@ class PageRepository extends Repository
     }
 
     /**
-     * Get basic wikidata on the page: label and description.
-     * @param Page $page
-     * @return string[][] In the format:
-     *    [[
-     *         'term' => string such as 'label',
-     *         'term_text' => string (value for 'label'),
-     *     ], ... ]
-     */
-    public function getWikidataInfo(Page $page): array
-    {
-        if (empty($page->getWikidataId())) {
-            return [];
-        }
-
-        $wikidataId = ltrim($page->getWikidataId(), 'Q');
-        $lang = $page->getProject()->getLang();
-        $wdp = 'wikidatawiki_p';
-
-        $sql = "SELECT wby_name AS term, wbx_text AS term_text
-                FROM $wdp.wbt_item_terms
-                JOIN $wdp.wbt_term_in_lang ON wbit_term_in_lang_id = wbtl_id
-                JOIN $wdp.wbt_type ON wbtl_type_id = wby_id
-                JOIN $wdp.wbt_text_in_lang ON wbtl_text_in_lang_id = wbxl_id
-                JOIN $wdp.wbt_text ON wbxl_text_id = wbx_id
-                WHERE wbit_item_id = :wikidataId
-                AND wby_name IN ('label', 'description')
-                AND wbxl_language = :lang";
-
-        return $this->executeProjectsQuery('wikidatawiki', $sql, [
-            'lang' => $lang,
-            'wikidataId' => $wikidataId,
-        ])->fetchAllAssociative();
-    }
-
-    /**
      * Get or count all wikidata items for the given page,
      *     not just languages of sister projects
      * @param Page $page

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -225,45 +225,6 @@ class PageTest extends TestAdapter
     }
 
     /**
-     * Wikidata errors. With this test getWikidataInfo doesn't return a Description,
-     *     so getWikidataErrors should complain accordingly
-     */
-    public function testWikidataErrors(): void
-    {
-        $this->pageRepo->method('getWikidataInfo')
-            ->with()
-            ->willReturn([
-                [
-                    'term' => 'label',
-                    'term_text' => 'My article',
-                ],
-            ]);
-        $this->pageRepo->method('getPageInfo')
-            ->with()
-            ->willReturn([
-                'pagelanguage' => 'en',
-                'pageprops' => [
-                    'wikibase_item' => 'Q123',
-                ],
-            ]);
-
-        $page = new Page($this->pageRepo, new Project('exampleWiki'), 'Page');
-        $wikidataErrors = $page->getWikidataErrors();
-
-        static::assertArraySubset(
-            [
-                'prio' => 3,
-                'name' => 'Wikidata',
-            ],
-            $wikidataErrors[0]
-        );
-        static::assertStringContainsString(
-            'Description',
-            $wikidataErrors[0]['notice']
-        );
-    }
-
-    /**
      * Test getErros and getCheckWikiErrors.
      */
     public function testErrors(): void
@@ -278,23 +239,9 @@ class PageTest extends TestAdapter
                 'explanation' => 'This is how to fix the error',
             ],
         ];
-        $wikidataErrors = [
-            [
-                'prio' => 3,
-                'name' => 'Wikidata',
-                'notice' => 'Description for language <em>en</em> is missing',
-                'explanation' => "See: <a target='_blank' " .
-                    "href='//www.wikidata.org/wiki/Help:Description'>Help:Description</a>",
-            ],
-        ];
 
         $this->pageRepo->method('getCheckWikiErrors')
             ->willReturn($checkWikiErrors);
-        $this->pageRepo->method('getWikidataInfo')
-            ->willReturn([[
-                'term' => 'label',
-                'term_text' => 'My article',
-            ]]);
         $this->pageRepo->method('getPageInfo')
             ->willReturn([
                 'pagelanguage' => 'en',
@@ -306,10 +253,7 @@ class PageTest extends TestAdapter
         $page->setRepository($this->pageRepo);
 
         static::assertEquals($checkWikiErrors, $page->getCheckWikiErrors());
-        static::assertEquals(
-            array_merge($wikidataErrors, $checkWikiErrors),
-            $page->getErrors()
-        );
+        static::assertEquals($checkWikiErrors, $page->getErrors());
     }
 
     /**


### PR DESCRIPTION
This query has broken multiple times of the years as the Wikidata database schema is updated for scalability needs. The "errors" reported were limited to just a missing label and description, and even then XTools incorrectly did not check the language fallback chain.

If this functionality is to be restored, it should use the API, per T398932#10984530.

Bug: T398932