### PR TITLE
PagesCreated: don't count classes in non-pa namespaces; also fix unknown discard

### DIFF
--- a/src/Model/Pages.php
+++ b/src/Model/Pages.php
@@ -283,12 +283,14 @@ class Pages extends Model
             );
         } else {
             $counts = [];
-            foreach ($this->pages as $nsPages) {
-                foreach ($nsPages as $page) {
-                    if (!isset($counts[$page['assessment']['class'] ?? 'Unknown'])) {
-                        $counts[$page['assessment']['class'] ?? 'Unknown'] = 1;
-                    } else {
-                        $counts[$page['assessment']['class'] ?? 'Unknown']++;
+            foreach ($this->pages as $ns => $nsPages) {
+                if ($this->project->hasPageAssessments($ns)) {
+                    foreach ($nsPages as $page) {
+                        if (!isset($counts[$page['assessment']['class'] ?: 'Unknown'])) {
+                            $counts[$page['assessment']['class'] ?: 'Unknown'] = 1;
+                        } else {
+                            $counts[$page['assessment']['class'] ?: 'Unknown']++;
+                        }
                     }
                 }
             }
@@ -439,7 +441,7 @@ class Pages extends Model
                 unset($pageData['recreated']);
             }
 
-            if ($this->project->hasPageAssessments()) {
+            if ($this->project->hasPageAssessments($pageData['namespace'])) {
                 $attrs = $this->project
                     ->getPageAssessments()
                     ->getClassAttrs($row['pa_class'] ?: 'Unknown');

--- a/tests/Model/PagesTest.php
+++ b/tests/Model/PagesTest.php
@@ -37,7 +37,6 @@ class PagesTest extends TestAdapter
         $this->project->method('getPageAssessments')
             ->willReturn($pa);
         $this->project->method('hasPageAssessments')
-            ->with(0)
             ->willReturn(true);
         $this->project->method('getNamespaces')
             ->willReturn([0 => 'Main', 1 => 'Talk', 3 => 'User_talk']);


### PR DESCRIPTION
Using `$project->getPageAssessments()::SUPPORTED_NAMESPACES`. This prevents our noting that eg user talk 534 pages are 'Unknown'.

Also, on the side, fix a bug introduced by #526 : the != "" in WHERE meant we discarded all pages with any unknown assessments in all circumstances; whereas we should only discard the unknown assessment there's another one. As a side note, knowing that this query doesn't care about namespaces, this meant that PagesCreated briefly stopped returning anything.