### PR TITLE
PageInfo: used cached version of main query

### DIFF
--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -302,10 +302,17 @@ class Page extends Model
      * @param User|null $user Specify to get only revisions by the given user.
      * @param false|int $start
      * @param false|int $end
+     * @param int|null $limit
+     * @param int|null $numRevisions
      * @return array
      */
-    public function getRevisions(?User $user = null, $start = false, $end = false, ?int $limit = null, ?int $numRevisions = null): array
-    {
+    public function getRevisions(
+        ?User $user = null,
+        $start = false,
+        $end = false,
+        ?int $limit = null,
+        ?int $numRevisions = null
+    ): array {
         if (isset($this->revisions)) {
             return $this->revisions;
         }

--- a/src/Model/Page.php
+++ b/src/Model/Page.php
@@ -304,13 +304,13 @@ class Page extends Model
      * @param false|int $end
      * @return array
      */
-    public function getRevisions(?User $user = null, $start = false, $end = false): array
+    public function getRevisions(?User $user = null, $start = false, $end = false, ?int $limit = null, ?int $numRevisions = null): array
     {
         if (isset($this->revisions)) {
             return $this->revisions;
         }
 
-        $this->revisions = $this->repository->getRevisions($this, $user, $start, $end);
+        $this->revisions = $this->repository->getRevisions($this, $user, $start, $end, $limit, $numRevisions);
 
         return $this->revisions;
     }

--- a/src/Model/PageInfo.php
+++ b/src/Model/PageInfo.php
@@ -487,12 +487,12 @@ class PageInfo extends PageInfoApi
         $limit = $this->tooManyRevisions() ? $this->repository->getMaxPageRevisions() : null;
 
         // Third parameter is ignored if $limit is null.
-        $revStmt = $this->page->getRevisionsStmt(
+        $revs = $this->page->getRevisions(
             null,
-            $limit,
-            $this->getNumRevisions(),
             $this->start,
-            $this->end
+            $this->end,
+            $limit,
+            $this->getNumRevisions()
         );
         $revCount = 0;
 
@@ -518,7 +518,7 @@ class PageInfo extends PageInfoApi
             'maxDeletion' => null,
         ];
 
-        while ($rev = $revStmt->fetchAssociative()) {
+        foreach ($revs as $rev) {
             /** @var Edit $edit */
             $edit = $this->repository->getEdit($this->page, $rev);
 

--- a/src/Model/PageInfo.php
+++ b/src/Model/PageInfo.php
@@ -486,7 +486,7 @@ class PageInfo extends PageInfoApi
     {
         $limit = $this->tooManyRevisions() ? $this->repository->getMaxPageRevisions() : null;
 
-        // Third parameter is ignored if $limit is null.
+        // numRevisions is ignored if $limit is null.
         $revs = $this->page->getRevisions(
             null,
             $this->start,

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -105,14 +105,14 @@ class PageRepository extends Repository
      * @param false|int $end
      * @return string[] Each member with keys: id, timestamp, length.
      */
-    public function getRevisions(Page $page, ?User $user = null, $start = false, $end = false): array
+    public function getRevisions(Page $page, ?User $user = null, $start = false, $end = false, ?int $limit = null, ?int $numRevisions = null): array
     {
         $cacheKey = $this->getCacheKey(func_get_args(), 'page_revisions');
         if ($this->cache->hasItem($cacheKey)) {
             return $this->cache->getItem($cacheKey)->get();
         }
 
-        $stmt = $this->getRevisionsStmt($page, $user, null, null, $start, $end);
+        $stmt = $this->getRevisionsStmt($page, $user, $limit, $numRevisions, $start, $end);
         $result = $stmt->fetchAllAssociative();
 
         // Cache and return.

--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -103,10 +103,18 @@ class PageRepository extends Repository
      * @param User|null $user Specify to get only revisions by the given user.
      * @param false|int $start
      * @param false|int $end
+     * @param int|null $limit
+     * @param int|null $numRevisions
      * @return string[] Each member with keys: id, timestamp, length.
      */
-    public function getRevisions(Page $page, ?User $user = null, $start = false, $end = false, ?int $limit = null, ?int $numRevisions = null): array
-    {
+    public function getRevisions(
+        Page $page,
+        ?User $user = null,
+        $start = false,
+        $end = false,
+        ?int $limit = null,
+        ?int $numRevisions = null
+    ): array {
         $cacheKey = $this->getCacheKey(func_get_args(), 'page_revisions');
         if ($this->cache->hasItem($cacheKey)) {
             return $this->cache->getItem($cacheKey)->get();


### PR DESCRIPTION
Essentially switch from getRevisionsStmt to getRevisions. Needs to be reviewed for memory; I did some tests, but I'm not very knowledgeable on performance and the limits of the prod servers.

Bug: T208543