### PR TITLE
I18nHelper: validate language codes, falling back to English

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "doctrine/doctrine-migrations-bundle": "~2.0",
         "eightpoints/guzzle-bundle": "^8.0",
         "jms/serializer-bundle": "^3.4",
-        "krinkle/intuition": "^1.0",
+        "krinkle/intuition": "^2.3",
         "mediawiki/oauthclient": "^1.2",
         "nelmio/api-doc-bundle": "~4.11",
         "nelmio/cors-bundle": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e94ab2e289755c4e4008a75508a62bf",
+    "content-hash": "703e2fe31c048f721ed6cf0461c723e3",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -2074,32 +2074,31 @@
         },
         {
             "name": "krinkle/intuition",
-            "version": "v1.2.0",
+            "version": "v2.3.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Krinkle/intuition.git",
-                "reference": "dee3883497dae9b7f48c6b3e4faba711367745b1"
+                "url": "https://github.com/wikimedia/labs-tools-intuition.git",
+                "reference": "5871a02c009621cf7c1bc1a240fab30688b9db48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Krinkle/intuition/zipball/dee3883497dae9b7f48c6b3e4faba711367745b1",
-                "reference": "dee3883497dae9b7f48c6b3e4faba711367745b1",
+                "url": "https://api.github.com/repos/wikimedia/labs-tools-intuition/zipball/5871a02c009621cf7c1bc1a240fab30688b9db48",
+                "reference": "5871a02c009621cf7c1bc1a240fab30688b9db48",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "jakub-onderka/php-parallel-lint": "1.0.0",
-                "mediawiki/mediawiki-codesniffer": "22.0.0",
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^6.5.11"
+                "mediawiki/mediawiki-codesniffer": "32.0.0",
+                "php-coveralls/php-coveralls": "^2.4",
+                "php-parallel-lint/php-parallel-lint": "^1.0.0",
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
             "autoload": {
                 "files": [
-                    "src/defines.php",
-                    "src/compat.php"
+                    "src/defines.php"
                 ],
                 "psr-0": {
                     "MessagesFunctions": "language/"
@@ -2114,10 +2113,9 @@
             ],
             "description": "Framework for localisation in PHP.",
             "support": {
-                "issues": "https://github.com/Krinkle/intuition/issues",
-                "source": "https://github.com/Krinkle/intuition/tree/release"
+                "source": "https://github.com/wikimedia/labs-tools-intuition/tree/v2.3.6"
             },
-            "time": "2018-11-06T18:04:32+00:00"
+            "time": "2024-03-28T22:32:35+00:00"
         },
         {
             "name": "laminas/laminas-code",

--- a/tests/Helper/I18nHelperTest.php
+++ b/tests/Helper/I18nHelperTest.php
@@ -9,6 +9,7 @@ use App\Tests\SessionHelper;
 use App\Tests\TestAdapter;
 use DateTime;
 use Krinkle\Intuition\Intuition;
+use Symfony\Component\HttpFoundation\Session\Session;
 
 /**
  * @covers \App\Helper\I18nHelper
@@ -18,12 +19,13 @@ class I18nHelperTest extends TestAdapter
     use SessionHelper;
 
     protected I18nHelper $i18n;
+    protected Session $session;
 
     public function setUp(): void
     {
-        $session = $this->createSession(static::createClient());
+        $this->session = $this->createSession(static::createClient());
         $this->i18n = new I18nHelper(
-            $this->getRequestStack($session),
+            $this->getRequestStack($this->session),
             static::getContainer()->getParameter('kernel.project_dir')
         );
     }
@@ -63,5 +65,14 @@ class I18nHelperTest extends TestAdapter
         static::assertEquals($datetime, $this->i18n->dateFormat('2023-01-23T12:34'));
         static::assertEquals($datetime, $this->i18n->dateFormat(new DateTime($datetime)));
         static::assertEquals($datetime, $this->i18n->dateFormat(1674477240));
+    }
+
+    public function testGetIntuitionInvalidLang(): void
+    {
+        $invalidI18n = new I18nHelper(
+            $this->getRequestStack($this->session, ['uselang' => 'invalid-lang']),
+            static::getContainer()->getParameter('kernel.project_dir')
+        );
+        static::assertEquals('en', $invalidI18n->getLang());
     }
 }


### PR DESCRIPTION
PHP 8.1+ is more strict with language codes. This commit guards against
a "Found unconstructed IntlDateFormatter" by validating the language
code.

Bump krinkle/intuition to the latest

Add test

Bug: T400929
Bug: T393736
