### PR TITLE
Bump mediawiki/oauthclient to 2.0.* and set user agent in requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "eightpoints/guzzle-bundle": "^8.0",
         "jms/serializer-bundle": "^3.4",
         "krinkle/intuition": "^2.3",
-        "mediawiki/oauthclient": "^1.2",
+        "mediawiki/oauthclient": "2.0.*",
         "nelmio/api-doc-bundle": "~4.11",
         "nelmio/cors-bundle": "^2.3",
         "phpdocumentor/reflection-docblock": "^5.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "703e2fe31c048f721ed6cf0461c723e3",
+    "content-hash": "f2ec431a83186af43899673da601b33e",
     "packages": [
         {
             "name": "composer/package-versions-deprecated",
@@ -2182,30 +2182,30 @@
         },
         {
             "name": "mediawiki/oauthclient",
-            "version": "1.2.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/mediawiki-oauthclient-php.git",
-                "reference": "ace642e67b8292a5e351c50daca7d3f2b25fa4cb"
+                "reference": "77db605711071ad1ef6afc0860216a53ef8a99b2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/mediawiki-oauthclient-php/zipball/ace642e67b8292a5e351c50daca7d3f2b25fa4cb",
-                "reference": "ace642e67b8292a5e351c50daca7d3f2b25fa4cb",
+                "url": "https://api.github.com/repos/wikimedia/mediawiki-oauthclient-php/zipball/77db605711071ad1ef6afc0860216a53ef8a99b2",
+                "reference": "77db605711071ad1ef6afc0860216a53ef8a99b2",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "php": ">=7.2.9",
+                "php": ">=7.4",
                 "psr/log": "^1.0"
             },
             "require-dev": {
-                "mediawiki/mediawiki-codesniffer": "37.0.0",
+                "mediawiki/mediawiki-codesniffer": "41.0.0",
                 "mediawiki/minus-x": "1.1.1",
-                "php-parallel-lint/php-console-highlighter": "0.5.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.0",
-                "phpunit/phpunit": "^8.5"
+                "php-parallel-lint/php-console-highlighter": "1.0.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpunit/phpunit": "9.5.28"
             },
             "type": "library",
             "autoload": {
@@ -2238,7 +2238,7 @@
                 "issues": "https://phabricator.wikimedia.org/tag/oauth/",
                 "source": "https://github.com/wikimedia/oauthclient-php/"
             },
-            "time": "2021-10-21T13:34:48+00:00"
+            "time": "2023-03-30T19:44:06+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -2639,16 +2639,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.2",
+            "version": "5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62"
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/92dde6a5919e34835c506ac8c523ef095a95ed62",
-                "reference": "92dde6a5919e34835c506ac8c523ef095a95ed62",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
                 "shasum": ""
             },
             "require": {
@@ -2697,9 +2697,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.2"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
             },
-            "time": "2025-04-13T19:20:35+00:00"
+            "time": "2025-08-01T19:43:32+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -7900,16 +7900,16 @@
         },
         {
             "name": "zircote/swagger-php",
-            "version": "5.2.0",
+            "version": "5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zircote/swagger-php.git",
-                "reference": "b82e160f9dcc9c5c5e59bf9a4904ed4a8ffa86a4"
+                "reference": "e174ef759a934c337209dc41c7490919c2362df8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/b82e160f9dcc9c5c5e59bf9a4904ed4a8ffa86a4",
-                "reference": "b82e160f9dcc9c5c5e59bf9a4904ed4a8ffa86a4",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/e174ef759a934c337209dc41c7490919c2362df8",
+                "reference": "e174ef759a934c337209dc41c7490919c2362df8",
                 "shasum": ""
             },
             "require": {
@@ -7980,9 +7980,9 @@
             ],
             "support": {
                 "issues": "https://github.com/zircote/swagger-php/issues",
-                "source": "https://github.com/zircote/swagger-php/tree/5.2.0"
+                "source": "https://github.com/zircote/swagger-php/tree/5.3.1"
             },
-            "time": "2025-08-11T04:26:13+00:00"
+            "time": "2025-08-16T22:59:55+00:00"
         }
     ],
     "packages-dev": [

--- a/config/packages/eight_points_guzzle.yaml
+++ b/config/packages/eight_points_guzzle.yaml
@@ -6,4 +6,5 @@ eight_points_guzzle:
             options:
                 headers:
                     Accept: "application/json"
+                    User-Agent: 'XTools/%env(APP_VERSION)% (https://xtools.wmcloud.org %env(MAILER_TO_EMAIL)%) GuzzleHttp'
                 timeout: 30

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -42,6 +42,7 @@ parameters:
     enable.TopEdits: '%env(bool:APP_ENABLE_TOPEDITS)%'
     oauth_key: '%env(OAUTH_KEY)%'
     oauth_secret: '%env(OAUTH_SECRET)%'
+    mailer.to_email: '%env(MAILER_TO_EMAIL)%'
 
 services:
     _defaults:
@@ -107,7 +108,7 @@ services:
     # These need to not be public, but they are, for now...
     app.automated_edits_helper:
         class: App\Helper\AutomatedEditsHelper
-        arguments: ['@request_stack', '@cache.app']
+        arguments: ['@request_stack', '@cache.app', 'eight_points_guzzle.client.xtools']
         public: true
     app.i18n_helper:
         class: App\Helper\I18nHelper

--- a/src/Controller/XtoolsController.php
+++ b/src/Controller/XtoolsController.php
@@ -198,6 +198,7 @@ abstract class XtoolsController extends AbstractController
      * @param ProjectRepository $projectRepo
      * @param UserRepository $userRepo
      * @param PageRepository $pageRepo
+     * @param Environment $twig
      * @param bool $isWMF
      * @param string $defaultProject
      */

--- a/src/Helper/AutomatedEditsHelper.php
+++ b/src/Helper/AutomatedEditsHelper.php
@@ -16,7 +16,6 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
  */
 class AutomatedEditsHelper
 {
-    protected CacheItemPoolInterface $cache;
     protected SessionInterface $session;
 
     /** @var array The list of tools that are considered reverting. */
@@ -29,11 +28,14 @@ class AutomatedEditsHelper
      * AutomatedEditsHelper constructor.
      * @param RequestStack $requestStack
      * @param CacheItemPoolInterface $cache
+     * @param \GuzzleHttp\Client $guzzle
      */
-    public function __construct(RequestStack $requestStack, CacheItemPoolInterface $cache)
-    {
+    public function __construct(
+        RequestStack $requestStack,
+        protected CacheItemPoolInterface $cache,
+        protected \GuzzleHttp\Client $guzzle
+    ) {
         $this->session = $requestStack->getSession();
-        $this->cache = $cache;
     }
 
     /**
@@ -99,7 +101,7 @@ class AutomatedEditsHelper
                 $uri
             ));
         } else {
-            $resp = json_decode(file_get_contents($uri));
+            $resp = json_decode($this->guzzle->get($uri)->getBody()->getContents());
         }
 
         $ret = json_decode($resp->query->pages[0]->revisions[0]->slots->main->content, true);

--- a/tests/TestAdapter.php
+++ b/tests/TestAdapter.php
@@ -70,7 +70,8 @@ class TestAdapter extends WebTestCase
         $session = $this->createSession($client);
         return new AutomatedEditsHelper(
             $this->getRequestStack($session),
-            static::getContainer()->get('cache.app')
+            static::getContainer()->get('cache.app'),
+            static::getContainer()->get('eight_points_guzzle.client.xtools')
         );
     }
 }


### PR DESCRIPTION
The WMF cluster now requires a user agent, see https://w.wiki/4wJS This gets set for all Guzzle requests, which is what we should use instead of file_get_contents() etc. Later when we upgrade Symfony, we'll move to Symfony's Guzzle-compatible HTTP client.

The host in the Guzzle user agent is hard-coded in YAML configuration for now.

Bug: T400929