### PR TITLE
TopEdits: add summary section, include total edits

### DIFF
--- a/src/Model/TopEdits.php
+++ b/src/Model/TopEdits.php
@@ -152,17 +152,26 @@ class TopEdits extends Model
      */
     public function getNumTopEdits(): int
     {
-        return count($this->topEdits);
+        if (isset($this->page)) {
+            return count($this->topEdits);
+        }
+        return $this->repository->countEdits(
+            $this->project,
+            $this->user,
+            $this->namespace,
+            $this->start,
+            $this->end
+        );
     }
 
     /**
      * Get the WikiProject totals.
-     * @param int Namespace ID.
-     * @return string[]|int
+     * @param int $ns Namespace ID.
+     * @return array
      */
-    public function getProjectTotals(int $ns) : array
+    public function getProjectTotals(int $ns): array
     {
-        if ($this->getNumPagesAnyNamespace($ns) > $this->limit) {
+        if ($this->getNumPagesNamespace() > $this->limit) {
             $projectTotals = $this->repository->getProjectTotals(
                 $this->project,
                 $this->user,
@@ -265,34 +274,14 @@ class TopEdits extends Model
 
     /**
      * Get the total number of pages edited in the namespace.
-     * @return int|null
+     * @return int
      */
-    public function getNumPagesNamespace(): ?int
+    public function getNumPagesNamespace(): int
     {
-        if ('all' === $this->namespace) {
-            return null;
-        }
-
-        return (int)$this->repository->countEditsNamespace(
+        return (int)$this->repository->countPagesNamespace(
             $this->project,
             $this->user,
             $this->namespace,
-            $this->start,
-            $this->end
-        );
-    }
-
-    /**
-     * Get the total number of pages edited in a given namespace.
-     * @param int $ns
-     * @return int|null
-     */
-    public function getNumPagesAnyNamespace(int $ns): ?int
-    {
-        return (int)$this->repository->countEditsNamespace(
-            $this->project,
-            $this->user,
-            $ns,
             $this->start,
             $this->end
         );

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -168,7 +168,7 @@ class TopEditsRepository extends UserRepository
     }
 
     /**
-     * Count the number of edits in the given namespace.
+     * Count the number of pages edited in the given namespace.
      * @param Project $project
      * @param User $user
      * @param int|string $namespace
@@ -176,7 +176,7 @@ class TopEditsRepository extends UserRepository
      * @param int|false $end End date as Unix timestamp.
      * @return mixed
      */
-    public function countEditsNamespace(Project $project, User $user, $namespace, $start = false, $end = false)
+    public function countPagesNamespace(Project $project, User $user, $namespace, $start = false, $end = false)
     {
         // Set up cache.
         $cacheKey = $this->getCacheKey(func_get_args(), 'topedits_count_ns');
@@ -187,6 +187,7 @@ class TopEditsRepository extends UserRepository
         $revDateConditions = $this->getDateConditions($start, $end);
         $pageTable = $project->getTableName('page');
         $revisionTable = $project->getTableName('revision');
+        $nsCondition = is_numeric($namespace) ? 'AND page_namespace = :namespace' : '';
 
         $ipcJoin = '';
         $whereClause = 'rev_actor = :actorId';
@@ -203,7 +204,7 @@ class TopEditsRepository extends UserRepository
                 JOIN $revisionTable ON page_id = rev_page
                 $ipcJoin
                 WHERE $whereClause
-                AND page_namespace = :namespace
+                $nsCondition
                 $revDateConditions";
 
         $resultQuery = $this->executeQuery($sql, $project, $user, $namespace, $params);

--- a/templates/autoEdits/result.html.twig
+++ b/templates/autoEdits/result.html.twig
@@ -41,7 +41,7 @@
                     {% if ae.end is not empty %}
                         <tr>
                             <td>{{ msg('end') }}</td>
-                            <td class="xt-test--end-date">{{ ae.endDate }}</td>
+                            <td>{{ ae.endDate }}</td>
                         </tr>
                     {% endif %}
                     <tr>

--- a/templates/categoryEdits/result.html.twig
+++ b/templates/categoryEdits/result.html.twig
@@ -59,7 +59,7 @@
                     {% if ce.end is not empty %}
                         <tr>
                             <td>{{ msg('end') }}</td>
-                            <td class="xt-test--end-date">{{ ce.endDate }}</td>
+                            <td>{{ ce.endDate }}</td>
                         </tr>
                     {% endif %}
 

--- a/templates/editCounter/general_stats.html.twig
+++ b/templates/editCounter/general_stats.html.twig
@@ -128,7 +128,7 @@
         {% if not(user.isIpRange) %}
             <tr>
                 <td><strong>{{ msg('total-edits') }}</strong></td>
-                <td class="xt-test--total-edits"><strong>{{ ec.countAllRevisions|num_format }}</strong></td>
+                <td><strong>{{ ec.countAllRevisions|num_format }}</strong></td>
             </tr>
         {% endif %}
     </tbody></table>

--- a/templates/pages/result.html.twig
+++ b/templates/pages/result.html.twig
@@ -43,7 +43,7 @@
                     {% if pages.end is not empty %}
                         <tr>
                             <td>{{ msg('end') }}</td>
-                            <td class="xt-test--end-date">{{ pages.endDate }}</td>
+                            <td>{{ pages.endDate }}</td>
                         </tr>
                     {% endif %}
                 </tbody></table>

--- a/templates/topedits/result_namespace.html.twig
+++ b/templates/topedits/result_namespace.html.twig
@@ -14,6 +14,40 @@
             {% if project.userHasOptedIn(user) and te.topEdits|length > 2 %}
                 {{ layout.nsToc(project, te.topEdits|keys) }}
             {% endif %}
+
+            {% set content %}
+                <div class="col-lg-6 stat-list clearfix">
+                    <table class="table"><tbody>
+                        <tr>
+                            <td>{{ msg('namespace') }}</td>
+                            <td>
+                                {{ nsName(te.namespace, project.namespaces) }}
+                            </td>
+                        </tr>
+                        {% if te.start is not empty %}
+                            <tr>
+                                <td>{{ msg('start') }}</td>
+                                <td>{{ te.startDate }}</td>
+                            </tr>
+                        {% endif %}
+                        {% if te.end is not empty %}
+                            <tr>
+                                <td>{{ msg('end') }}</td>
+                                <td>{{ te.endDate }}</td>
+                            </tr>
+                        {% endif %}
+                        <tr>
+                            <td class="stat-list--new-group">{{ msg('total-edits') }}</td>
+                            <td class="stat-list--new-group">{{ te.numTopEdits|num_format }}</td>
+                        </tr>
+                        <tr>
+                            <td>{{ msg('unique-pages-edited') }}</td>
+                            <td>{{ te.getNumPagesNamespace|num_format }}</td>
+                        </tr>
+                    </tbody></table>
+                </div>
+            {% endset %}
+            {{ layout.content_block('summary', content) }}
 {% endif %}
 
 {% if not(project.userHasOptedIn(user)) %}
@@ -22,9 +56,8 @@
     {% for ns, pages in te.topEdits %}
         {% set showPageAssessment = project.hasPageAssessments(ns) %}
         {% set content %}
-        <p>{{ te.numPagesAnyNamespace(ns)|num_format }} {{ msg('pages')|lower }}.</p>
-        <div class="side-to-side">
-            <div><table class="table table-bordered table-hover table-striped topedits-namespace-table xt-show-hide--target">
+        <div class="side-to-side xt-show-hide--target">
+            <div><table class="table table-bordered table-hover table-striped topedits-namespace-table">
                 <thead><tr>
                     <th>
                         <span class="sort-link sort-link--edits" data-column="edits">
@@ -79,7 +112,7 @@
                     {% if pages|length >= 10 and te.topEdits|length > 1 %}
                         <tr>
                             <td colspan={{ showPageAssessment ? 4 : 3 }}>
-                                <a href="{{ path('TopEditsResultNamespace', {project:project.domain, username:user.usernameIdent, namespace:ns}) }}">
+                                <a href="{{ path('TopEditsResultNamespace', {project:project.domain, username:user.usernameIdent, namespace:ns, start:te.startDate, end:te.endDate}) }}">
                                     {{ msg('more') }}&hellip;
                                 </a>
                             </td>
@@ -127,7 +160,7 @@
             {% set numPages = (te.getNumPagesNamespace / te.limit)|round(0, 'ceil') %}
             {% set hasPrev = te.pagination - 1 >= 0 %}
             {% set hasNext = te.pagination + 1 < numPages %}
-            {% set pathVars = {'project': project.domain, 'username': user.usernameIdent, 'namespace': te.namespace} %}
+            {% set pathVars = {'project': project.domain, 'username': user.usernameIdent, 'namespace': te.namespace, 'start': te.startDate, 'end': te.endDate} %}
 
             {% if hasNext or hasPrev %}
                 <nav aria-label="...">
@@ -166,13 +199,10 @@
                 <small class='xt-show'>[{{ msg('show')|lower }}]</small>
                 <small class='xt-hide'>[{{ msg('hide')|lower }}]</small>
             </h4>
-        {% endif %}
-
-        {% if is_sub_request %}
             {{ content }}
         {% else %}
             {% set downloadLink %}
-                {{ layout.downloadLink('TopEditsResultNamespace', {'project': project.domain, 'username': user.usernameIdent, 'namespace': te.namespace}, ['wikitext'], 'UserApiTopEditsNamespace') }}
+                {{ layout.downloadLink('TopEditsResultNamespace', {'project': project.domain, 'username': user.usernameIdent, 'namespace': te.namespace, 'start': te.startDate, 'end': te.endDate}, ['wikitext'], 'UserApiTopEditsNamespace') }}
             {% endset %}
             {{ layout.content_block(nsName(ns, project.namespaces), content, downloadLink, ns, true, te.topEdits|length > 1) }}
         {% endif %}

--- a/templates/topedits/result_page.html.twig
+++ b/templates/topedits/result_page.html.twig
@@ -57,7 +57,7 @@
                     {% if te.end is not empty %}
                         <tr>
                             <td>{{ msg('end') }}</td>
-                            <td class="xt-test--end-date">{{ te.endDate }}</td>
+                            <td>{{ te.endDate }}</td>
                         </tr>
                     {% endif %}
                     <tr>


### PR DESCRIPTION
This commit began as just a fix for the show/hide links next to the
namespace headings when viewing TopEdits from an EditCounter result.
Then I noticed TopEdits::getNumPagesAnyNamespace() was being called 22+
times (for each namespace), which is far too inefficient. I think the
more meaningful statistic for the 'all' namespaces view is unique pages
edited across all the namespaces. Conveniently, this query is already
ran as is necessary for pagination, so there's no cost added.

Rename TopEditsRepository::countEditsNamespace() to what it actually is,
::countPagesNamespace(), and give it proper support for 'all'
namespaces. Thus, we no longer need TopEdits::getNumPagesAnyNamespace().

One thing led to another, and we are now showing the familiar "Summary"
section on TopEdits namespace result pages. This also surfaces the
start/end date, which should be there to begin with for clarity and
consistency with other result pages.

Rework TopEdits::getNumTopEdits() to do more what it sounds like: for
TopEdits namespace, it gives the count of total edits. Before this
method was only used for TopEdits per page. The "Total edits" for the
given conditions (namespace, date range) is now exposed. In my tests it
can add a few seconds for extremely prolific users, but usually it's
quite fast.

Finally, fix pagination links to use the start and end dates when
applicable.

Bug: T218531
