### PR TITLE
PageInfoApi: ensure rev_timestamp is a number

### DIFF
--- a/src/Repository/PageInfoRepository.php
+++ b/src/Repository/PageInfoRepository.php
@@ -362,6 +362,7 @@ class PageInfoRepository extends AutoEditsRepository
                         FROM $revTable
                         JOIN $actorTable ON actor_id = rev_actor
                         WHERE rev_page = :pageid
+                        AND rev_timestamp > 0 # Protects from weird revs with rev_timestamp containing only null bytes
                         ORDER BY rev_timestamp ASC
                         LIMIT 1
                     ) b,
@@ -372,6 +373,7 @@ class PageInfoRepository extends AutoEditsRepository
                         JOIN $pageTable ON page_id = rev_page
                         WHERE rev_page = :pageid
                         AND rev_id = page_latest
+                        AND rev_timestamp > 0 # Protects from weird revs with rev_timestamp containing only null bytes
                     ) c
                 )";
         $params = ['pageid' => $page->getId()];


### PR DESCRIPTION
In some particularly weird situations, (eg https://foundation.wikimedia.org/w/index.php?title=Home&action=history&offset=20040705235959), some apparently corrupted rows have fourteen null bytes (not null itself, mind you) as timestamp. These rows also tend to have other trouble, such as an actor that has no row in the user table and no name. That causes some issues. This patch ensures we only take revisions where the rev_id is a strictly positive number (well, a string that evaluates to that). Doesn't read any more rows.