### PR TITLE
PageInfo: fix encoding errors in subpage count

### DIFF
--- a/src/Repository/PageInfoRepository.php
+++ b/src/Repository/PageInfoRepository.php
@@ -240,15 +240,16 @@ class PageInfoRepository extends AutoEditsRepository
 
         $project = $page->getProject();
         $pageTable = $project->getTableName('page');
-        $title = $page->getTitleWithoutNamespace();
+        $title = str_replace(' ', '_', $page->getTitleWithoutNamespace());
         $ns = $page->getNamespace();
 
         $sql = "SELECT COUNT(page_id) as `count`
             FROM $pageTable
-            WHERE page_title LIKE '$title/%'
-            AND page_namespace = $ns";
+            WHERE page_title LIKE :title
+            AND page_namespace = :namespace";
 
-        $result = $this->executeProjectsQuery($project, $sql)->fetchAllAssociative();
+        $result = $this->executeProjectsQuery($project, $sql, ['title' => $title . '/%', 'namespace' => $ns])
+            ->fetchAllAssociative();
 
         return $this->setCache($cacheKey, $result[0]['count']);
     }


### PR DESCRIPTION
My fault: I forgot to use proper SQL parameters and directly injected into the SQL, which causes encoding issues. (And could maybe perhaps be a security issue, theoretically?)

Oh and also, much less important, forgot to convert spaces to underscores.

Bug: T402709