### PR TITLE
Edit.php: wikify: fix link regex (page titles cannot contain []s)

### DIFF
--- a/src/Model/Edit.php
+++ b/src/Model/Edit.php
@@ -381,7 +381,7 @@ class Edit extends Model
 
         $linkMatch = null;
 
-        while (preg_match_all("/\[\[:?(.*?)]]/", $summary, $linkMatch)) {
+        while (preg_match_all("/\[\[:?([^\[\]]*?)]]/", $summary, $linkMatch)) {
             $wikiLinkParts = explode('|', $linkMatch[1][0]);
             $wikiLinkPath = htmlspecialchars($wikiLinkParts[0]);
             $wikiLinkText = htmlspecialchars(


### PR DESCRIPTION
Does exactly what it says on the tin.

Given how trivial and self-evident this is, i'm self-merging

Bug: T408332