### PR TITLE
Temp disable sha1 until we can fix uses properly

### DIFF
--- a/src/Repository/PageRepository.php
+++ b/src/Repository/PageRepository.php
@@ -166,6 +166,7 @@ class PageRepository extends Repository
 
         $dateConditions = $this->getDateConditions($start, $end, false, 'revs.');
 
+        // sha1 temporarily disabled, see T407814/T389026
         $sql = "SELECT * FROM (
                     SELECT
                         revs.rev_id AS `id`,
@@ -176,7 +177,7 @@ class PageRepository extends Repository
                         actor_user AS user_id,
                         actor_name AS username,
                         comment_text AS `comment`,
-                        revs.rev_sha1 AS `sha`,
+                        /* revs.rev_sha1 AS `sha`, */
                         revs.rev_deleted AS `deleted`,
                         (
                             SELECT JSON_ARRAYAGG(ctd_name)

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -414,12 +414,12 @@ class TopEditsRepository extends UserRepository
         $commentTable = $project->getTableName('comment');
         $tagTable = $project->getTableName('change_tag');
         $tagDefTable = $project->getTableName('change_tag_def');
-
+        // sha1 temporarily disabled, see T407814/T389026
         if ($childRevs) {
             $childSelect = ", (
                     CASE WHEN
-                        childrevs.rev_sha1 = parentrevs.rev_sha1
-                        OR (
+                        /* childrevs.rev_sha1 = parentrevs.rev_sha1
+                        OR */ (
                             SELECT 1
                             FROM $tagTable
                             WHERE ct_rev_id = revs.rev_id


### PR DESCRIPTION
With https://phabricator.wikimedia.org/T389026, all of our uses of sha1 are currently broken (have been so for about 24 hours I'd say), and given they're used in pagerepo and topeditsrepo it's causing quite a mess.

I'm temporarily commenting out our two uses to prevent the immediate mess and give us time to think this out properly.

Bug: T407814