### PR TITLE
PageInfo: restore 'Top 10 by added text' chart

### DIFF
--- a/src/Repository/EditCounterRepository.php
+++ b/src/Repository/EditCounterRepository.php
@@ -608,7 +608,7 @@ class EditCounterRepository extends Repository
                     LIMIT 5000
                 ) data";
         $results = $this->executeProjectsQuery($project, $sql, $params)->fetchAssociative();
-        $results['sizes'] = json_decode($results['sizes']);
+        $results['sizes'] = json_decode($results['sizes'] ?? '[]');
         $results['average_size'] = count($results['sizes']) > 0
             ? array_sum($results['sizes'])/count($results['sizes'])
             : 0;


### PR DESCRIPTION
Seems to work identical to before by joining on the slots and content tables. I spot-checked a few articles and the numbers look right.

TopEdits still isn't fixed and may be a bit involved as it looks at the sha1 of child revisions.

Bug: T407814