### PR TITLE
TopEdits: fix wikitext output for top projects and simplify queries

### DIFF
--- a/src/Model/TopEdits.php
+++ b/src/Model/TopEdits.php
@@ -171,36 +171,13 @@ class TopEdits extends Model
      */
     public function getProjectTotals(int $ns): array
     {
-        if ($this->getNumPagesNamespace() > $this->limit) {
-            $projectTotals = $this->repository->getProjectTotals(
-                $this->project,
-                $this->user,
-                $ns,
-                $this->start,
-                $this->end
-            );
-        } else {
-            $counts_tmp = [];
-            // List of pages for this namespace
-            $rows = $this->topEdits[$ns];
-            foreach ($rows as $row) {
-                $num = $row["count"];
-                // May be null or nonexistent for assessment-less pages
-                $titles = $row["pap_project_title"] ?? "{}";
-                // Had to use json to pass multiple values in SQL select
-                foreach (json_decode($titles) as $projectName) {
-                    $counts_tmp[$projectName] ??= 0;
-                    $counts_tmp[$projectName] += $num;
-                }
-            }
-            arsort($counts_tmp);
-            $counts_tmp = array_slice($counts_tmp, 0, 10);
-            $projectTotals = [];
-            foreach ($counts_tmp as $project => $count) {
-                $projectTotals[] = [ "pap_project_title" => $project, "count" => $count ];
-            }
-        }
-        return $projectTotals;
+        return $this->repository->getProjectTotals(
+            $this->project,
+            $this->user,
+            $ns,
+            $this->start,
+            $this->end
+        );
     }
 
     /**

--- a/src/Repository/TopEditsRepository.php
+++ b/src/Repository/TopEditsRepository.php
@@ -122,16 +122,6 @@ class TopEditsRepository extends UserRepository
                     LIMIT 1
                 ) AS pa_class"
             : '';
-        $paProjectsTable = $project->getTableName('page_assessments_projects');
-        $paProjectsSelect = $hasPageAssessments
-            ? ", (
-                    SELECT JSON_ARRAYAGG(pap_project_title)
-                    FROM $paTable
-                    JOIN $paProjectsTable
-                    ON pa_project_id = pap_project_id
-                    WHERE pa_page_id = page_id
-                ) AS pap_project_title"
-            : '';
 
         $ipcJoin = '';
         $whereClause = 'rev_actor = :actorId';
@@ -147,7 +137,6 @@ class TopEditsRepository extends UserRepository
         $sql = "SELECT page_namespace AS `namespace`, page_title,
                     page_is_redirect AS `redirect`, COUNT(page_title) AS `count`
                     $paSelect
-                    $paProjectsSelect
                 FROM $pageTable
 
                 JOIN $revisionTable ON page_id = rev_page
@@ -309,17 +298,6 @@ class TopEditsRepository extends UserRepository
                     LIMIT 1
                 ) AS pa_class"
             : '';
-        $paProjectsTable = $project->getTableName('page_assessments_projects');
-        $paProjectsSelect = $hasPageAssessments
-            ? ", (
-                    SELECT JSON_ARRAYAGG(pap_project_title)
-                    FROM $pageAssessmentsTable
-                    JOIN $paProjectsTable
-                    ON pa_project_id = pap_project_id
-                    WHERE pa_page_id = e.page_id
-                ) AS pap_project_title"
-            : '';
-
 
         $ipcJoin = '';
         $whereClause = 'rev_actor = :actorId';
@@ -332,7 +310,7 @@ class TopEditsRepository extends UserRepository
         }
 
         $sql = "SELECT c.page_namespace AS `namespace`, e.page_title,
-                    c.page_is_redirect AS `redirect`, c.count $paSelect $paProjectsSelect
+                    c.page_is_redirect AS `redirect`, c.count $paSelect
                 FROM
                 (
                     SELECT b.page_namespace, b.page_is_redirect, b.rev_page, b.count

--- a/templates/topedits/result_namespace.wikitext.twig
+++ b/templates/topedits/result_namespace.wikitext.twig
@@ -41,13 +41,13 @@
 |}
 {% if showPageAssessment %}
 {% set totals = te.projectTotals(ns) %}
-{% if totals|keys|length > 0 %}
+{% if totals|length > 0 %}
 {| class="wikitable sortable"
 |+ {{ msg('top-wikiprojects') }}
 ! {{ msg('wikiproject') }} !! {{ msg('count') }}
-{% for wikiproject, count in totals %}
+{% for row in totals %}
 |-
-| {{ wikiproject }} || {{ count|num_format }}
+| {{ row.pap_project_title }} || {% verbatim %}{{FORMATNUM:{% endverbatim %}{{ row.count }}}}
 {% endfor %}
 |}
 {% endif %}

--- a/tests/Model/PageTest.php
+++ b/tests/Model/PageTest.php
@@ -229,7 +229,7 @@ class PageTest extends TestAdapter
      */
     public function testErrors(): void
     {
-        $this->markTestSkipped( 'Broken until T413013 is fixed' );
+        $this->markTestSkipped('Broken until T413013 is fixed');
         $checkWikiErrors = [
             [
                 'error' => '61',


### PR DESCRIPTION
I believe I even requested to combine into one query, but inadvertently this put it in the API output as a serialized JSON string. That could be fixed, but this wasn't intended to be there to begin with. Also, combining the queries is only applicable when there is one page of results, which is usually only the case for less prolific users - in which case doing a separate query is negligible. So this just simplifies things.