### PR TITLE
Fix a typo

### DIFF
--- a/templates/pageInfo/pageinfo.js.twig
+++ b/templates/pageInfo/pageinfo.js.twig
@@ -40,6 +40,6 @@ $(() => {
         '&uselang=' + mw.config.get('wgUserLanguage')
     ).done(function (result) {
         $result.html(result);
-        clearInterval(loadinganimation);
+        clearInterval(loadingAnimation);
     });
 });


### PR DESCRIPTION
[The last commit](https://github.com/x-tools/xtools/commit/08c58c4036022c78542c51116395c9dfe62eecb6) renamed `loadinganimation` to `loadingAnimation` without also changing the reference to that variable.